### PR TITLE
renames Assignment.user to .assignedUser, adds some descriptions

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1,12 +1,35 @@
 type Assignment {
+  """
+  The user assigned to this assignment
+  """
+  assignedUser: User!
   createdAt: ISO8601DateTime!
+
+  """
+  The date the assignment ends
+  """
   endsOn: ISO8601Date
   id: ID!
+
+  """
+  The project this assignment is for
+  """
   project: Project!
+
+  """
+  The date the assignment starts
+  """
   startsOn: ISO8601Date
+
+  """
+  The status of the assignment
+  """
   status: String!
   updatedAt: ISO8601DateTime!
-  user: User!
+
+  """
+  The work weeks for this assignment
+  """
   workWeeks: [WorkWeek!]!
 }
 

--- a/app/graphql/types/staff_plan/assignment_type.rb
+++ b/app/graphql/types/staff_plan/assignment_type.rb
@@ -4,15 +4,15 @@ module Types
   module StaffPlan
     class AssignmentType < Types::BaseObject
       field :id, ID, null: false
-      field :user, Types::StaffPlan::UserType, null: false
-      field :project, Types::StaffPlan::ProjectType, null: false
-      field :status, String, null: false
-      field :starts_on, GraphQL::Types::ISO8601Date, null: true
-      field :ends_on, GraphQL::Types::ISO8601Date, null: true
+      field :assigned_user, Types::StaffPlan::UserType, null: false, description: 'The user assigned to this assignment'
+      field :project, Types::StaffPlan::ProjectType, null: false, description: 'The project this assignment is for'
+      field :status, String, null: false, description: 'The status of the assignment'
+      field :starts_on, GraphQL::Types::ISO8601Date, null: true, description: 'The date the assignment starts'
+      field :ends_on, GraphQL::Types::ISO8601Date, null: true, description: 'The date the assignment ends'
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :work_weeks, [Types::StaffPlan::WorkWeekType], null: false
+      field :work_weeks, [Types::StaffPlan::WorkWeekType], null: false, description: 'The work weeks for this assignment'
 
       def work_weeks
         object.work_weeks


### PR DESCRIPTION
Closes https://github.com/goinvo/staffplan_redux/issues/97

Renames Assignment.user to Assignment.assignedUser in the GraphQL schema.

cc @MyStarrySpace