### PR TITLE
ignore stripe webhook's inability to find subs for now

### DIFF
--- a/app/commands/stripe/customer_updated.rb
+++ b/app/commands/stripe/customer_updated.rb
@@ -9,7 +9,7 @@ module Stripe
       company = Company.find_by(stripe_id: @customer.id)
 
       if company.blank?
-        Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
+        # Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
         return
       end
 

--- a/app/commands/stripe/subscription_updated.rb
+++ b/app/commands/stripe/subscription_updated.rb
@@ -7,7 +7,7 @@ module Stripe
     def call
       company = Company.find_by(stripe_id: @subscription.customer)
       if company.blank?
-        Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
+        # Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
         return
       end
 

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -43,7 +43,7 @@ class Webhooks::StripeController < ApplicationController
     subscription = event.data.object
     company = Company.find_by(stripe_id: subscription.customer)
     if company.blank?
-      Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
+      # Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
       return
     end
 
@@ -67,7 +67,7 @@ class Webhooks::StripeController < ApplicationController
     subscription = event.data.object
     company = Company.find_by(stripe_id: subscription.customer)
     if company.blank?
-      Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
+      # Rollbar.report_message("Customer not found for Stripe ID: #{@customer.id}", 'warning')
       return
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,6 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
-    Bullet.alert         = true
     Bullet.bullet_logger = true
     Bullet.console       = true
     Bullet.rails_logger  = true


### PR DESCRIPTION
Does two things:

* quiets Rollbar errors when a webhook can't find a subscription. This will make sense to re-enable when we have the real server pointed to the production Stripe account, for now it's just noise.
* quiets Bullet locally, so it won't show a JS alert when it finds an N+1 or extraneous query