### PR TITLE
Adds User#avatarUrl to GraphQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ spec/examples.txt
 /config/credentials/production.key
 config/credentials/test.key
 config/credentials/development.key
+
+.venv

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -363,6 +363,7 @@ type User {
   Fetches all of the user's assignments for the current company.
   """
   assignments: [Assignment!]!
+  avatarUrl: String!
 
   """
   Fetches all companies for the current user.

--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -7,8 +7,8 @@ module Types
       field :name, String, null: false
       field :email, String, null: false
       field :current_company_id, ID, null: true
-      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :avatar_url, String, null: false
 
       field :companies, [Types::StaffPlan::CompanyType], null: false, description: "Fetches all companies for the current user."
 
@@ -27,6 +27,9 @@ module Types
       def projects
         object.projects.where(client_id: object.current_company.clients.map(&:id))
       end
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,8 +19,6 @@ module ApplicationHelper
     link_to text, path, class: css_classes
   end
   def user_gravatar(user:, css_classes: "h-8 w-8 rounded-full")
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "http://secure.gravatar.com/avatar/#{gravatar_id}"
-    image_tag(gravatar_url, alt: user.name, class: css_classes)
+    image_tag(user.gravatar_url, alt: user.name, class: css_classes)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,6 @@ module ApplicationHelper
     link_to text, path, class: css_classes
   end
   def user_gravatar(user:, css_classes: "h-8 w-8 rounded-full")
-    image_tag(user.gravatar_url, alt: user.name, class: css_classes)
+    image_tag(user.avatar_url, alt: user.name, class: css_classes)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,4 +39,9 @@ class User < ApplicationRecord
 
     SyncCustomerSubscriptionJob.perform_async(current_company.id)
   end
+
+  def avatar_url
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    "http://secure.gravatar.com/avatar/#{gravatar_id}"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   end
 
   def avatar_url
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_id = Digest::MD5::hexdigest(email.downcase)
     "http://secure.gravatar.com/avatar/#{gravatar_id}"
   end
 end


### PR DESCRIPTION
Just adds the value on `UserType` for now. This will currently only return the Gravatar URL for the user's `email` field. Soon I'll be adding a user profile management section where we'll let people upload an avatar URL for themselves.