### PR TITLE
Adds company and client avatar management

### DIFF
--- a/app/commands/avatar_helper.rb
+++ b/app/commands/avatar_helper.rb
@@ -1,6 +1,4 @@
 class AvatarHelper
-  include ActionController::Helpers
-
   attr_accessor :target, :size
 
   def initialize(target:, size: 80, css_classes: "h-8 w-8 rounded-full")

--- a/app/commands/avatar_helper.rb
+++ b/app/commands/avatar_helper.rb
@@ -1,0 +1,25 @@
+class AvatarHelper
+  include ActionController::Helpers
+
+  attr_accessor :target, :size
+
+  def initialize(target:, size: 80, css_classes: "h-8 w-8 rounded-full")
+    @target = target
+    @size = size
+    @css_classes = css_classes
+  end
+
+  def image_url
+    if target.avatar.attached?
+      Rails.application.routes.url_helpers.url_for(target.avatar.variant(:thumb))
+    else
+      case target
+      when User
+        gravatar_id = Digest::MD5::hexdigest(target.email.downcase)
+        "http://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+      else
+        "http://www.gravatar.com/avatar"
+      end
+    end
+  end
+end

--- a/app/components/settings/users/list_item_component.html.erb
+++ b/app/components/settings/users/list_item_component.html.erb
@@ -1,6 +1,6 @@
 <li class="relative flex justify-between gap-x-6 py-5">
   <div class="flex min-w-0 gap-x-4">
-    <%= helpers.user_gravatar(user: @user, css_classes: "h-12 w-12 flex-none rounded-full bg-gray-50") %>
+    <%= helpers.gravatar_url(target: @user, css_classes: "h-12 w-12 flex-none rounded-full bg-gray-50") %>
     <div class="min-w-0 flex-auto">
       <p class="text-sm font-semibold leading-6 text-gray-900">
         <%= link_to settings_user_path(@user) do %>

--- a/app/components/settings/users/list_item_component.html.erb
+++ b/app/components/settings/users/list_item_component.html.erb
@@ -1,6 +1,6 @@
 <li class="relative flex justify-between gap-x-6 py-5">
   <div class="flex min-w-0 gap-x-4">
-    <%= helpers.avatar_image_tag(target: @user, css_classes: "h-12 w-12 flex-none rounded-full bg-gray-50") %>
+    <%= image_tag AvatarHelper.new(target: @user).image_url, class: "h-12 w-12 flex-none rounded-full bg-gray-50" %>
     <div class="min-w-0 flex-auto">
       <p class="text-sm font-semibold leading-6 text-gray-900">
         <%= link_to settings_user_path(@user) do %>

--- a/app/components/settings/users/list_item_component.html.erb
+++ b/app/components/settings/users/list_item_component.html.erb
@@ -1,6 +1,6 @@
 <li class="relative flex justify-between gap-x-6 py-5">
   <div class="flex min-w-0 gap-x-4">
-    <%= helpers.gravatar_url(target: @user, css_classes: "h-12 w-12 flex-none rounded-full bg-gray-50") %>
+    <%= helpers.avatar_image_tag(target: @user, css_classes: "h-12 w-12 flex-none rounded-full bg-gray-50") %>
     <div class="min-w-0 flex-auto">
       <p class="text-sm font-semibold leading-6 text-gray-900">
         <%= link_to settings_user_path(@user) do %>

--- a/app/components/shared/manage_avatar_component.html.erb
+++ b/app/components/shared/manage_avatar_component.html.erb
@@ -4,7 +4,7 @@
     <% if @attachable.avatar.present? %>
       <%= image_tag(@attachable.avatar.variant(:thumb)) %>
     <% else %>
-      <%= helpers.gravatar_url(target: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
+      <%= helpers.avatar_image_tag(target: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
     <% end %>
     <%= f.file_field :avatar,
                      class: "hidden",

--- a/app/components/shared/manage_avatar_component.html.erb
+++ b/app/components/shared/manage_avatar_component.html.erb
@@ -4,7 +4,7 @@
     <% if @attachable.avatar.present? %>
       <%= image_tag(@attachable.avatar.variant(:thumb)) %>
     <% else %>
-      <%= helpers.user_gravatar(user: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
+      <%= helpers.gravatar_url(target: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
     <% end %>
     <%= f.file_field :avatar,
                      class: "hidden",

--- a/app/components/shared/manage_avatar_component.html.erb
+++ b/app/components/shared/manage_avatar_component.html.erb
@@ -4,7 +4,7 @@
     <% if @attachable.avatar.present? %>
       <%= image_tag(@attachable.avatar.variant(:thumb)) %>
     <% else %>
-      <%= helpers.avatar_image_tag(target: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
+      <%= image_tag AvatarHelper.new(target: @attachable, size: 200).image_url, class: "h-32 w-32 rounded-full text-gray-300" %>
     <% end %>
     <%= f.file_field :avatar,
                      class: "hidden",

--- a/app/components/shared/manage_avatar_component.html.erb
+++ b/app/components/shared/manage_avatar_component.html.erb
@@ -23,7 +23,7 @@
     <% if @attachable.avatar.present? %>
       <p class="mt-1">
         <%= link_to "Remove",
-                    avatars_path,
+                    avatars_path(attachable: { redirect_to: request.path, type: @attachable.class.name, id: @attachable.id }),
                     data: {
                       "turbo-method": :delete,
                       "turbo-confirm": "Are you sure?"

--- a/app/components/shared/manage_avatar_component.html.erb
+++ b/app/components/shared/manage_avatar_component.html.erb
@@ -1,0 +1,35 @@
+<div class="col-span-full">
+  <%= f.label :avatar, "Avatar", class: "block text-sm font-medium leading-6 text-gray-900" %>
+  <div class="mt-2 flex items-center gap-x-3" data-controller="avatar-file">
+    <% if @attachable.avatar.present? %>
+      <%= image_tag(@attachable.avatar.variant(:thumb)) %>
+    <% else %>
+      <%= helpers.user_gravatar(user: @attachable, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
+    <% end %>
+    <%= f.file_field :avatar,
+                     class: "hidden",
+                     accept: ".jpg,.jpeg,.png,.gif",
+                     data: {
+                       "avatar-file-target" => "fileInput",
+                       "action" => "change->avatar-file#change"
+                     } %>
+    <button type="button"
+            data-avatar-file-target="changeButton"
+            data-action="click->avatar-file#click"
+            class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+      Change
+    </button>
+
+    <% if @attachable.avatar.present? %>
+      <p class="mt-1">
+        <%= link_to "Remove",
+                    avatars_path,
+                    data: {
+                      "turbo-method": :delete,
+                      "turbo-confirm": "Are you sure?"
+                    }, class: "text-sm font-semibold text-red-600"
+        %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/shared/manage_avatar_component.rb
+++ b/app/components/shared/manage_avatar_component.rb
@@ -1,0 +1,12 @@
+module Shared
+  class ManageAvatarComponent < ViewComponent::Base
+    def initialize(attachable:, form:)
+      @attachable = attachable
+      @form = form
+    end
+
+    def f
+      @form
+    end
+  end
+end

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -2,7 +2,7 @@ class AvatarsController < ApplicationController
   before_action :require_user!
   def destroy
     current_user.avatar.purge if current_user.avatar.attached?
-    flash[:success] = "Custom avatar deleted successfully. Gravatar will be used."
+    flash[:success] = "Custom avatar deleted successfully."
     redirect_to users_profile_path
   end
 end

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -1,8 +1,50 @@
 class AvatarsController < ApplicationController
   before_action :require_user!
+  before_action :find_attachable
   def destroy
-    current_user.avatar.purge if current_user.avatar.attached?
+    @attachable.avatar.purge if @attachable.avatar.attached?
     flash[:success] = "Custom avatar deleted successfully."
-    redirect_to users_profile_path
+    redirect_to attachable_params[:redirect_to] || root_path
+  end
+
+  private
+
+  # TODO: extract this to a command object
+  def find_attachable
+    unless %w(User Company Client).include?(attachable_params[:type])
+      flash[:error] = "No attachment found."
+    end
+
+    attachable = attachable_params[:type].constantize.find(attachable_params[:id])
+
+    case attachable_params[:type]
+    when "User"
+      # only users change their avatar
+      if attachable == current_user
+        @attachable = current_user
+      else
+        flash[:error] = "Sorry, you can't remove that attachment."
+        redirect_to attachable_params[:redirect_to] || root_path and return
+      end
+    when "Company"
+      # admins and owners can change the current company's avatar
+      if attachable == current_company &&
+        current_company.admin_or_owner?(user: current_user)
+        @attachable = current_company
+      else
+        flash[:error] = "Sorry, you can't remove that attachment."
+        redirect_to attachable_params[:redirect_to] || root_path and return
+      end
+    when "Client"
+      # anyone can change a client's avatar
+      @attachable = current_company.clients.find(attachable_params[:id])
+    end
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = "Sorry, you can't remove that attachment."
+    redirect_to attachable_params[:redirect_to] || root_path
+  end
+
+  def attachable_params
+    params.require(:attachable).permit(:type, :id, :redirect_to)
   end
 end

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -50,6 +50,6 @@ class ClientsController < ApplicationController
     end
 
     def update_client_params
-      params.require(:client).permit(:name, :description, :status)
+      params.require(:client).permit(:name, :description, :status, :avatar)
     end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -17,6 +17,6 @@ class SettingsController < ApplicationController
   private
 
   def update_params
-    params.require(:company).permit(:name)
+    params.require(:company).permit(:name, :avatar)
   end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -56,6 +56,7 @@ enum AssignmentStatus {
 }
 
 type Client {
+  avatarUrl: String!
   createdAt: ISO8601DateTime!
   description: String
   id: ID!
@@ -78,6 +79,7 @@ enum ClientStatus {
 }
 
 type Company {
+  avatarUrl: String!
   clients: [Client!]!
   createdAt: ISO8601DateTime!
   id: ID!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -372,7 +372,7 @@ type User {
   """
   companies: [Company!]!
   createdAt: ISO8601DateTime!
-  currentCompanyId: ID
+  currentCompany: Company
   email: String!
   id: ID!
   name: String!

--- a/app/graphql/types/staff_plan/client_type.rb
+++ b/app/graphql/types/staff_plan/client_type.rb
@@ -10,7 +10,7 @@ module Types
 
       field :avatar_url, String, null: false
       def avatar_url
-        helpers.avatar_image_url(target: object)
+        AvatarHelper.new(target: object).image_url
       end
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/staff_plan/client_type.rb
+++ b/app/graphql/types/staff_plan/client_type.rb
@@ -7,6 +7,12 @@ module Types
       field :name, String, null: false
       field :description, String, null: true
       field :status, Enums::ClientStatus, null: false
+
+      field :avatar_url, String, null: false
+      def avatar_url
+        helpers.avatar_image_url(target: object)
+      end
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/graphql/types/staff_plan/company_type.rb
+++ b/app/graphql/types/staff_plan/company_type.rb
@@ -5,6 +5,12 @@ module Types
     class CompanyType < Types::BaseObject
       field :id, ID, null: false
       field :name, String, null: false
+
+      field :avatar_url, String, null: false
+      def avatar_url
+        helpers.avatar_image_url(target: object)
+      end
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/graphql/types/staff_plan/company_type.rb
+++ b/app/graphql/types/staff_plan/company_type.rb
@@ -8,7 +8,7 @@ module Types
 
       field :avatar_url, String, null: false
       def avatar_url
-        helpers.avatar_image_url(target: object)
+        AvatarHelper.new(target: object).image_url
       end
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -9,6 +9,9 @@ module Types
       field :current_company_id, ID, null: true
 
       field :avatar_url, String, null: false
+      def avatar_url
+        helpers.avatar_image_url(target: object)
+      end
 
       field :companies, [Types::StaffPlan::CompanyType], null: false, description: "Fetches all companies for the current user."
 

--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
+include ActionController::Helpers
+
 module Types
   module StaffPlan
     class UserType < Types::BaseObject
       field :id, ID, null: false
       field :name, String, null: false
       field :email, String, null: false
-      field :current_company_id, ID, null: true
+      field :current_company, Types::StaffPlan::CompanyType, null: true
 
       field :avatar_url, String, null: false
       def avatar_url
-        helpers.avatar_image_url(target: object)
+        AvatarHelper.new(target: object).image_url
       end
 
       field :companies, [Types::StaffPlan::CompanyType], null: false, description: "Fetches all companies for the current user."

--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-include ActionController::Helpers
-
 module Types
   module StaffPlan
     class UserType < Types::BaseObject

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,11 +18,21 @@ module ApplicationHelper
 
     link_to text, path, class: css_classes
   end
-  def gravatar_url(target:, size: 80, css_classes: "h-8 w-8 rounded-full")
-    if target.has_gravatar?
-      image_tag(target.avatar_url(size:), alt: target.name, class: css_classes)
+
+  def avatar_image_url(target:, size: 80)
+    if target.avatar.attached?
+      target.avatar.variant(:thumb)
     else
-      image_tag("http://www.gravatar.com/avatar")
+      case target
+      when User
+        gravatar_id = Digest::MD5::hexdigest(target.email.downcase)
+        "http://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+      else
+        "http://www.gravatar.com/avatar"
+      end
     end
+  end
+  def avatar_image_tag(target:, size: 80, css_classes: "h-8 w-8 rounded-full")
+    image_tag(avatar_image_url(target:, size:), alt: target.name, class: css_classes)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,11 @@ module ApplicationHelper
 
     link_to text, path, class: css_classes
   end
-  def user_gravatar(user:, size: 80, css_classes: "h-8 w-8 rounded-full")
-    image_tag(user.avatar_url(size:), alt: user.name, class: css_classes)
+  def gravatar_url(target:, size: 80, css_classes: "h-8 w-8 rounded-full")
+    if target.has_gravatar?
+      image_tag(target.avatar_url(size:), alt: target.name, class: css_classes)
+    else
+      image_tag("http://www.gravatar.com/avatar")
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,21 +18,4 @@ module ApplicationHelper
 
     link_to text, path, class: css_classes
   end
-
-  def avatar_image_url(target:, size: 80)
-    if target.avatar.attached?
-      target.avatar.variant(:thumb)
-    else
-      case target
-      when User
-        gravatar_id = Digest::MD5::hexdigest(target.email.downcase)
-        "http://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-      else
-        "http://www.gravatar.com/avatar"
-      end
-    end
-  end
-  def avatar_image_tag(target:, size: 80, css_classes: "h-8 w-8 rounded-full")
-    image_tag(avatar_image_url(target:, size:), alt: target.name, class: css_classes)
-  end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -4,6 +4,10 @@ class Client < ApplicationRecord
 
   has_paper_trail
 
+  has_one_attached :avatar do |attachable|
+    attachable.variant :thumb, resize_to_limit: [100, 100]
+  end
+
   ACTIVE = 'active'.freeze
   ARCHIVED = 'archived'.freeze
 
@@ -34,9 +38,5 @@ class Client < ApplicationRecord
         projects.update_all(status: Project::ARCHIVED)
       end
     end
-  end
-
-  def has_gravatar?
-    false
   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -35,4 +35,8 @@ class Client < ApplicationRecord
       end
     end
   end
+
+  def has_gravatar?
+    false
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -31,4 +31,8 @@ class Company < ApplicationRecord
     membership = memberships.find_by(user: user)
     membership.present? && membership.active?
   end
+
+  def has_gravatar?
+    false
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,6 +9,10 @@ class Company < ApplicationRecord
 
   has_paper_trail
 
+  has_one_attached :avatar do |attachable|
+    attachable.variant :thumb, resize_to_limit: [100, 100]
+  end
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   before_create :build_default_subscription
@@ -25,6 +29,10 @@ class Company < ApplicationRecord
 
   def owners
     memberships.owners.map(&:user)
+  end
+
+  def admin_or_owner?(user:)
+    user.owner?(company: self) || user.admin?(company: self)
   end
 
   def can_access?(user:)

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -39,8 +39,4 @@ class Company < ApplicationRecord
     membership = memberships.find_by(user: user)
     membership.present? && membership.active?
   end
-
-  def has_gravatar?
-    false
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,8 +43,4 @@ class User < ApplicationRecord
 
     SyncCustomerSubscriptionJob.perform_async(current_company.id)
   end
-
-  def has_gravatar?
-    true
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,15 +44,6 @@ class User < ApplicationRecord
     SyncCustomerSubscriptionJob.perform_async(current_company.id)
   end
 
-  def avatar_url(size: 80)
-    if avatar.attached?
-      avatar.variant(:thumb)
-    else
-      gravatar_id = Digest::MD5::hexdigest(email.downcase)
-      "http://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-    end
-  end
-
   def has_gravatar?
     true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
   has_many :projects, through: :assignments
   has_many :work_weeks, through: :assignments
 
-  has_one_attached :uploaded_avatar
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,4 +53,8 @@ class User < ApplicationRecord
       "http://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     end
   end
+
+  def has_gravatar?
+    true
+  end
 end

--- a/app/views/clients/edit.html.erb
+++ b/app/views/clients/edit.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <div class="bg-white p-4 mt-4">
-  <%= form_for @client, url: client_path(@client), data: {turbo: false} do |f| %>
+  <%= form_for @client, url: client_path(@client) do |f| %>
     <div class="space-y-12">
       <div class="pb-12">
         <h2 class="text-base font-semibold leading-7 text-gray-900">Add a new client</h2>
@@ -53,6 +53,8 @@
               <%= f.text_area :description, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
             </div>
           </div>
+
+          <%= render(Shared::ManageAvatarComponent.new(attachable: @client, form: f)) %>
         </div>
       </div>
     </div>

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -36,7 +36,7 @@
     <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
       <dt class="text-sm font-medium leading-6 text-gray-900">Avatar</dt>
       <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
-        <%= avatar_image_tag(target: @client, css_classes: "h-24 w-24 rounded-full") %>
+        <%= image_tag AvatarHelper.new(target: @client).image_url, class: "h-24 w-24 rounded-full" %>
       </dd>
     </div>
     <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -34,6 +34,12 @@
       </dd>
     </div>
     <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+      <dt class="text-sm font-medium leading-6 text-gray-900">Avatar</dt>
+      <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+        <%= avatar_image_tag(target: @client, css_classes: "h-24 w-24 rounded-full") %>
+      </dd>
+    </div>
+    <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
       <dt class="text-sm font-medium leading-6 text-gray-900">Projects</dt>
       <dd class="mt-2 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
         <ul role="list" class="divide-y divide-gray-100 rounded-md border border-gray-200">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
                               title="<%= current_user.email %>">
                         <span class="absolute -inset-1.5"></span>
                         <span class="sr-only">Open user menu</span>
-                        <%= avatar_image_tag(target: current_user) %>
+                        <%= image_tag(AvatarHelper.new(target: current_user).image_url, class: "h-8 w-8 rounded-full") %>
                       </button>
                     </div>
                     <div data-dropdown-target="menu"
@@ -123,7 +123,7 @@
           <div class="border-t border-gray-700 pb-3 pt-4">
             <div class="flex items-center px-5">
               <div class="flex-shrink-0">
-                <%= avatar_image_tag(target: current_user, css_classes: "h-10 w-10 rounded-full") %>
+                <%= image_tag(AvatarHelper.new(target: current_user).image_url, class: "h-10 w-10 rounded-full") %>
               </div>
               <div class="ml-3">
                 <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
                               title="<%= current_user.email %>">
                         <span class="absolute -inset-1.5"></span>
                         <span class="sr-only">Open user menu</span>
-                        <%= user_gravatar(user: current_user) %>
+                        <%= gravatar_url(target: current_user) %>
                       </button>
                     </div>
                     <div data-dropdown-target="menu"
@@ -123,7 +123,7 @@
           <div class="border-t border-gray-700 pb-3 pt-4">
             <div class="flex items-center px-5">
               <div class="flex-shrink-0">
-                <%= user_gravatar(user: current_user, css_classes: "h-10 w-10 rounded-full") %>
+                <%= gravatar_url(target: current_user, css_classes: "h-10 w-10 rounded-full") %>
               </div>
               <div class="ml-3">
                 <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
             <div class="flex items-center">
               <div class="flex-shrink-0">
                 <%= link_to root_path do %>
-                  <img class="h-8 w-8" src="https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=500" alt="Your Company">
+                  <img class="h-8 w-8 rounded-full" src="<%= AvatarHelper.new(target: current_company).image_url %>" alt="<%= current_company.name %>">
                 <% end %>
               </div>
               <div class="hidden md:block">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
                               title="<%= current_user.email %>">
                         <span class="absolute -inset-1.5"></span>
                         <span class="sr-only">Open user menu</span>
-                        <%= gravatar_url(target: current_user) %>
+                        <%= avatar_image_tag(target: current_user) %>
                       </button>
                     </div>
                     <div data-dropdown-target="menu"
@@ -123,7 +123,7 @@
           <div class="border-t border-gray-700 pb-3 pt-4">
             <div class="flex items-center px-5">
               <div class="flex-shrink-0">
-                <%= gravatar_url(target: current_user, css_classes: "h-10 w-10 rounded-full") %>
+                <%= avatar_image_tag(target: current_user, css_classes: "h-10 w-10 rounded-full") %>
               </div>
               <div class="ml-3">
                 <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>

--- a/app/views/passwordless/sessions/show.html.erb
+++ b/app/views/passwordless/sessions/show.html.erb
@@ -16,7 +16,6 @@
               <%= f.text_field :token, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
             </div>
           </div>
-
           <div>
             <%= f.submit t(".confirm"), class: "mt-2 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
           </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -19,6 +19,8 @@
       </div>
     </div>
 
+    <%= render(Shared::ManageAvatarComponent.new(attachable: current_company, form: f)) %>
+
     <div class="mt-6 flex items-center justify-end gap-x-6">
       <%= f.submit "Save", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
     </div>

--- a/app/views/users/profile/show.html.erb
+++ b/app/views/users/profile/show.html.erb
@@ -16,41 +16,7 @@
             </div>
           </div>
 
-          <div class="col-span-full">
-            <%= f.label :avatar, "Avatar", class: "block text-sm font-medium leading-6 text-gray-900" %>
-            <div class="mt-2 flex items-center gap-x-3" data-controller="avatar-file">
-              <% if current_user.avatar.present? %>
-                <%= image_tag(current_user.avatar.variant(:thumb)) %>
-              <% else %>
-                <%= user_gravatar(user: current_user, size: 200, css_classes: "h-32 w-32 rounded-full text-gray-300") %>
-              <% end %>
-              <%= f.file_field :avatar,
-                               class: "hidden",
-                               accept: ".jpg,.jpeg,.png,.gif",
-                               data: {
-                                 "avatar-file-target" => "fileInput",
-                                 "action" => "change->avatar-file#change"
-                               } %>
-              <button type="button"
-                      data-avatar-file-target="changeButton"
-                      data-action="click->avatar-file#click"
-                      class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                Change
-              </button>
-
-              <% if current_user.avatar.present? %>
-                <p class="mt-1">
-                  <%= link_to "Remove",
-                              avatars_path,
-                              data: {
-                                "turbo-method": :delete,
-                                "turbo-confirm": "Are you sure? This will use your Gravatar instead."
-                              }, class: "text-sm font-semibold text-red-600"
-                  %>
-                </p>
-              <% end %>
-            </div>
-          </div>
+          <%= render(Shared::ManageAvatarComponent.new(attachable: current_user, form: f)) %>
         </div>
       </div>
     </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,17 +89,4 @@ RSpec.describe User, type: :model do
       user.toggle_status!(company: user.current_company)
     end
   end
-
-  describe "#avatar_url" do
-    it "returns the gravatar URL if the user hasn't set an avatar" do
-      user = create(:user)
-      expect(user.avatar_url).to include("http://secure.gravatar.com/avatar")
-    end
-
-    it "returns the avatar URL if the user has set an avatar" do
-      user = create(:user)
-      user.update(avatar: fixture_file_upload("avatar.jpg", "image/jpg"))
-      expect(user.avatar_url).to be_a(ActiveStorage::VariantWithRecord)
-    end
-  end
 end

--- a/spec/requests/avatar_spec.rb
+++ b/spec/requests/avatar_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "Avatars", type: :request do
+
+  def attachable_params(attachable:, redirect_to:)
+    { attachable: { type: attachable.class.name, id: attachable.id, redirect_to: redirect_to } }
+  end
+
   context "when no use is logged in" do
     describe "DELETE /avatars" do
       it "redirects to the login page" do
@@ -10,26 +15,134 @@ RSpec.describe "Avatars", type: :request do
     end
   end
 
-  context "when logged in as a user" do
+  context "when logged in" do
     before do
       @user = FactoryBot.create(:user)
       passwordless_sign_in @user
     end
 
-    describe "DELETE /avatars" do
-      it "deletes the avatar and redirects back to the user profile" do
-        @user.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
-        expect(@user.avatar).to be_attached
-        delete avatars_path
-        expect(response).to redirect_to(users_profile_path)
-        expect(@user.reload.avatar).to_not be_attached
+    context "managing avatars" do
+      it "handles an attachable that's not found" do
+        delete avatars_path(attachable: { type: 'Company', id: 0, redirect_to: settings_path })
+        expect(response).to redirect_to(settings_path)
+        expect(flash[:error]).to eq("Sorry, you can't remove that attachment.")
       end
+    end
 
-      it "does nothing if the user has no avatar attached" do
-        expect(@user.avatar).to_not be_attached
-        delete avatars_path
-        expect(response).to redirect_to(users_profile_path)
-        expect(@user.reload.avatar).to_not be_attached
+    context "managing client avatars" do
+      describe "DELETE /avatars" do
+        it "allows anyone in the company to manage the client's avatar" do
+          client = create(:client, company: @user.current_company)
+          member = create(:membership, company: @user.current_company, role: 'member').user
+          passwordless_sign_in member
+
+          client.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(client.avatar).to be_attached
+
+          delete avatars_path(attachable_params(attachable: client, redirect_to: settings_path))
+
+          expect(response).to redirect_to(settings_path)
+          expect(flash[:success]).to eq("Custom avatar deleted successfully.")
+          expect(client.reload.avatar).to_not be_attached
+        end
+
+        it "deletes the avatar and redirects back to the settings page" do
+          client = create(:client, company: @user.current_company)
+          client.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(client.avatar).to be_attached
+
+          delete avatars_path(attachable_params(attachable: client, redirect_to: settings_path))
+
+          expect(response).to redirect_to(settings_path)
+          expect(client.reload.avatar).to_not be_attached
+        end
+
+        it "does nothing if the client has no avatar attached" do
+          client = create(:client, company: @user.current_company)
+          expect(client.avatar).to_not be_attached
+
+          delete avatars_path(attachable_params(attachable: client, redirect_to: settings_path))
+
+          expect(response).to redirect_to(settings_path)
+          expect(client.reload.avatar).to_not be_attached
+        end
+      end
+    end
+
+    context "managing company avatars" do
+      describe "DELETE /avatars" do
+        it "does not allow a non-admin or owner to delete the company avatar" do
+          company = @user.current_company
+          member = create(:membership, company: company, role: 'member').user
+          passwordless_sign_in member
+
+          company.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(company.avatar).to be_attached
+
+          delete avatars_path(attachable_params(attachable: company, redirect_to: settings_path))
+
+          expect(response).to redirect_to(settings_path)
+          expect(flash[:error]).to eq("Sorry, you can't remove that attachment.")
+          expect(company.reload.avatar).to be_attached
+        end
+
+        it "does not allow another company's avatar to be deleted" do
+          another_company = create(:company)
+          another_company.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(another_company.avatar).to be_attached
+
+          delete avatars_path(attachable_params(attachable: another_company, redirect_to: settings_path))
+
+          expect(response).to redirect_to(settings_path)
+          expect(flash[:error]).to eq("Sorry, you can't remove that attachment.")
+          expect(another_company.reload.avatar).to be_attached
+        end
+
+        it "deletes the avatar and redirects back to the settings page" do
+          company = @user.current_company
+          company.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(company.avatar).to be_attached
+          delete avatars_path(attachable_params(attachable: company, redirect_to: settings_path))
+          expect(response).to redirect_to(settings_path)
+          expect(company.reload.avatar).to_not be_attached
+        end
+
+        it "does nothing if the company has no avatar attached" do
+          company = @user.current_company
+          expect(company.avatar).to_not be_attached
+          delete avatars_path(attachable_params(attachable: company, redirect_to: settings_path))
+          expect(response).to redirect_to(settings_path)
+          expect(company.reload.avatar).to_not be_attached
+        end
+      end
+    end
+
+    context "managing user avatars" do
+      describe "DELETE /avatars" do
+        it "does not allow another user's avatar to be deleted" do
+          another_user = create(:user)
+          another_user.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(another_user.avatar).to be_attached
+          delete avatars_path(attachable_params(attachable: another_user, redirect_to: users_profile_path))
+          expect(response).to redirect_to(users_profile_path)
+          expect(flash[:error]).to eq("Sorry, you can't remove that attachment.")
+          expect(another_user.reload.avatar).to be_attached
+        end
+
+        it "deletes the avatar and redirects back to the user profile" do
+          @user.update(avatar: fixture_file_upload('avatar.jpg', 'image/jpg'))
+          expect(@user.avatar).to be_attached
+          delete avatars_path(attachable_params(attachable: @user, redirect_to: users_profile_path))
+          expect(response).to redirect_to(users_profile_path)
+          expect(@user.reload.avatar).to_not be_attached
+        end
+
+        it "does nothing if the user has no avatar attached" do
+          expect(@user.avatar).to_not be_attached
+          delete avatars_path(attachable_params(attachable: @user, redirect_to: users_profile_path))
+          expect(response).to redirect_to(users_profile_path)
+          expect(@user.reload.avatar).to_not be_attached
+        end
       end
     end
   end


### PR DESCRIPTION
### Adds Client and Company avatar management

Closes https://github.com/goinvo/staffplan_redux/issues/70
Closes https://github.com/goinvo/staffplan_redux/issues/85

#### Company avatar management

https://github.com/goinvo/staffplan_redux/assets/2804/750c044e-c863-4722-b771-41205205995c

Company avatar management is restricted to admins and owners of the company.

#### Client avatar management

https://github.com/goinvo/staffplan_redux/assets/2804/71c9e79a-785d-448c-99a5-629a31f565ba

All company members can manage client avatars.

### GraphQL fields

<img width="1875" alt="Screenshot 2024-03-30 at 1 57 37 PM" src="https://github.com/goinvo/staffplan_redux/assets/2804/cde5ae65-4c43-4f6a-bd93-6f37412d6dfa">

### Notes

I've restricted user avatar management to only allow someone to manage their own avatar.