### PR TITLE
Adds Assignment#estimatedWeeklyHours

### DIFF
--- a/app/graphql/mutations/upsert_assignment.rb
+++ b/app/graphql/mutations/upsert_assignment.rb
@@ -7,13 +7,14 @@ module Mutations
     argument :project_id, ID, required: true, description: "The ID of the project this assignment is being created for."
     argument :user_id, ID, required: true, description: "The ID of the user being assigned to the project."
     argument :status, String, required: true, description: "The status of the assignment."
+    argument :estimated_weekly_hours, Integer, required: false, description: "The estimated weekly hours for this assignment."
     argument :starts_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this assignment starts."
     argument :ends_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this assignment ends."
 
     # return type from the mutation
     type Types::StaffPlan::AssignmentType
 
-    def resolve(id: nil, project_id:, user_id:, status:, starts_on: nil, ends_on: nil)
+    def resolve(id: nil, project_id:, user_id:, status:, estimated_weekly_hours: nil, starts_on: nil, ends_on: nil)
       current_company = context[:current_company]
 
       # try and find the assignment
@@ -28,6 +29,7 @@ module Mutations
         assignment = project.assignments.new(user_id:, status:)
       end
 
+      assignment.assign_attributes(estimated_weekly_hours: estimated_weekly_hours) if estimated_weekly_hours
       assignment.assign_attributes(starts_on: starts_on) if starts_on
       assignment.assign_attributes(ends_on: ends_on) if ends_on
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -122,6 +122,11 @@ type Mutation {
     endsOn: ISO8601Date
 
     """
+    The estimated weekly hours for this assignment.
+    """
+    estimatedWeeklyHours: Int
+
+    """
     The ID of the assignment to update.
     """
     id: ID

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -9,6 +9,11 @@ type Assignment {
   The date the assignment ends
   """
   endsOn: ISO8601Date
+
+  """
+  The estimated weekly hours for this assignment
+  """
+  estimatedWeeklyHours: Int
   id: ID!
 
   """

--- a/app/graphql/types/staff_plan/assignment_type.rb
+++ b/app/graphql/types/staff_plan/assignment_type.rb
@@ -14,6 +14,7 @@ module Types
       field :status, Enums::AssignmentStatus, null: false, description: 'The status of the assignment'
       field :starts_on, GraphQL::Types::ISO8601Date, null: true, description: 'The date the assignment starts'
       field :ends_on, GraphQL::Types::ISO8601Date, null: true, description: 'The date the assignment ends'
+      field :estimated_weekly_hours, Integer, null: true, description: 'The estimated weekly hours for this assignment'
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/db/migrate/20240401012248_add_hours_to_assignment.rb
+++ b/db/migrate/20240401012248_add_hours_to_assignment.rb
@@ -1,0 +1,5 @@
+class AddHoursToAssignment < ActiveRecord::Migration[7.1]
+  def change
+    add_column :assignments, :estimated_weekly_hours, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_26_130503) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_01_012248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_26_130503) do
     t.datetime "updated_at", null: false
     t.date "starts_on"
     t.date "ends_on"
+    t.integer "estimated_weekly_hours"
     t.index ["project_id"], name: "index_assignments_on_project_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"
   end

--- a/spec/graphql/mutations/upsert_assignment_spec.rb
+++ b/spec/graphql/mutations/upsert_assignment_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Mutations::UpsertAssignment do
 
     it "updates the assignment with valid params" do
       query_string = <<-GRAPHQL
-        mutation($id: ID, $projectId: ID!, $userId: ID!, $status: String!, $startsOn: ISO8601Date, $endsOn: ISO8601Date) {
-          upsertAssignment(id: $id, projectId: $projectId, userId: $userId, status: $status, startsOn: $startsOn, endsOn: $endsOn) {
+        mutation($id: ID, $projectId: ID!, $userId: ID!, $status: String!, $estimatedWeeklyHours: Int, $startsOn: ISO8601Date, $endsOn: ISO8601Date) {
+          upsertAssignment(id: $id, projectId: $projectId, userId: $userId, status: $status, estimatedWeeklyHours: $estimatedWeeklyHours, startsOn: $startsOn, endsOn: $endsOn) {
             id
             project {
               id
@@ -60,6 +60,7 @@ RSpec.describe Mutations::UpsertAssignment do
               id
             }  
             status
+            estimatedWeeklyHours
             startsOn
             endsOn
           }
@@ -80,6 +81,7 @@ RSpec.describe Mutations::UpsertAssignment do
           projectId: assignment.project_id,
           userId: assignment.user_id,
           status: Assignment::ACTIVE,
+          estimatedWeeklyHours: estimated_weekly_hours = 40,
           startsOn: starts_on = 2.weeks.from_now.to_date.iso8601,
           endsOn: ends_on = 10.weeks.from_now.to_date.iso8601
         }
@@ -88,6 +90,7 @@ RSpec.describe Mutations::UpsertAssignment do
       post_result = result["data"]["upsertAssignment"]
       expect(result["errors"]).to be_nil
       expect(post_result["status"]).to eq(Assignment::ACTIVE)
+      expect(post_result["estimatedWeeklyHours"]).to eq(estimated_weekly_hours)
       expect(post_result["startsOn"]).to eq(starts_on.to_s)
       expect(post_result["endsOn"]).to eq(ends_on.to_s)
     end
@@ -121,7 +124,7 @@ RSpec.describe Mutations::UpsertAssignment do
         },
         variables: {
           id: assignment.id,
-          # projectId: create(:project).id,
+          projectId: create(:project).id,
           userId: assignment.user_id,
           status: Assignment::ACTIVE,
         }
@@ -129,7 +132,7 @@ RSpec.describe Mutations::UpsertAssignment do
 
       post_result = result["errors"]
       expect(post_result.length).to eq(1)
-      expect(post_result.first["message"]).to eq("Variable $projectId of type ID! was provided invalid value")
+      expect(post_result.first["message"]).to eq("Project and user must belong to the same company")
     end
 
     it "raises a 404 if given an assignment id that doesn't exist on the company" do


### PR DESCRIPTION
Closes https://github.com/goinvo/staffplan_redux/issues/141

Adds a field to the Assignment model to track the amount of time per week the assignment should default to for its `work_weeks.estimated_hours`.