### PR TITLE
Adds `fte` and `hours` fields to `projects`

### DIFF
--- a/app/graphql/mutations/upsert_project.rb
+++ b/app/graphql/mutations/upsert_project.rb
@@ -9,13 +9,26 @@ module Mutations
     argument :status, String, required: false, description: "The status of the project."
     argument :cost, Float, required: false, description: "The cost of the project."
     argument :payment_frequency, String, required: false, description: "The frequency of payment for the project."
+    argument :fte, Float, required: false, description: "The number of full time employees that will be assigned to this project."
+    argument :hours, Integer, required: false, description: "The expected number of billable hours expected for this project."
     argument :starts_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this project starts."
     argument :ends_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this project ends."
 
     # return type from the mutation
     type Types::StaffPlan::ProjectType, null: true
 
-    def resolve(id: nil, client_id: nil, name: nil, status: nil, cost: nil, payment_frequency: nil, starts_on: nil, ends_on: nil)
+    def resolve(
+      id: nil,
+      client_id: nil,
+      name: nil,
+      status: nil,
+      cost: nil,
+      payment_frequency: nil,
+      fte: nil,
+      hours: nil,
+      starts_on: nil,
+      ends_on: nil
+    )
       current_company = context[:current_company]
 
       # try and find the assignment
@@ -42,6 +55,8 @@ module Mutations
       project.assign_attributes(status:) if status.present?
       project.assign_attributes(cost:) if cost.present?
       project.assign_attributes(payment_frequency:) if payment_frequency.present?
+      project.assign_attributes(fte:) if fte.present?
+      project.assign_attributes(hours:) if hours.present?
       project.assign_attributes(starts_on:) if starts_on.present?
       project.assign_attributes(ends_on:) if ends_on.present?
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -197,6 +197,16 @@ type Mutation {
     endsOn: ISO8601Date
 
     """
+    The number of full time employees that will be assigned to this project.
+    """
+    fte: Float
+
+    """
+    The expected number of billable hours expected for this project.
+    """
+    hours: Int
+
+    """
     The ID of the project to update.
     """
     id: ID
@@ -259,6 +269,8 @@ type Project {
   cost: Float!
   createdAt: ISO8601DateTime!
   endsOn: ISO8601Date
+  fte: Float
+  hours: Int
   id: ID!
   name: String!
   paymentFrequency: ProjectPaymentFrequency!

--- a/app/graphql/types/staff_plan/project_type.rb
+++ b/app/graphql/types/staff_plan/project_type.rb
@@ -9,6 +9,8 @@ module Types
       field :status,  Enums::ProjectStatus, null: false
       field :cost, Float, null: false
       field :payment_frequency, Enums::ProjectPaymentFrequency, null: false
+      field :fte, Float, null: true
+      field :hours, Integer, null: true
       field :starts_on, GraphQL::Types::ISO8601Date, null: true
       field :ends_on, GraphQL::Types::ISO8601Date, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,6 +28,8 @@ class Project < ApplicationRecord
   validates :status, inclusion: { in: VALID_STATUSES }, allow_blank: true
   validates :cost, numericality: { greater_than_or_equal_to: 0.0 }, allow_blank: true
   validates :payment_frequency, inclusion: { in: VALID_PAYMENT_FREQUENCIES }, allow_blank: true
+  validates :fte, numericality: { greater_than_or_equal_to: 0.0 }, allow_blank: true
+  validates :hours, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
 
   def confirmed?
     status == CONFIRMED

--- a/db/migrate/20240405013815_add_fte_and_hours_to_projects.rb
+++ b/db/migrate/20240405013815_add_fte_and_hours_to_projects.rb
@@ -1,0 +1,6 @@
+class AddFteAndHoursToProjects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :fte, :decimal, precision: 8, scale: 2
+    add_column :projects, :hours, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_01_012248) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_05_013815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,6 +107,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_01_012248) do
     t.datetime "updated_at", null: false
     t.date "starts_on"
     t.date "ends_on"
+    t.decimal "fte", precision: 8, scale: 2
+    t.integer "hours"
     t.index ["client_id", "name"], name: "index_projects_on_client_id_and_name", unique: true
     t.index ["client_id"], name: "index_projects_on_client_id"
   end

--- a/spec/graphql/mutations/upsert_project_spec.rb
+++ b/spec/graphql/mutations/upsert_project_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Mutations::UpsertProject do
 
     it "updates a project with valid params" do
       query_string = <<-GRAPHQL
-        mutation($id: ID, $clientId: ID, $name: String, $status: String, $cost: Float, $paymentFrequency: String, $startsOn: ISO8601Date, $endsOn: ISO8601Date) {
-          upsertProject(id: $id, clientId: $clientId, name: $name, status: $status, cost: $cost, paymentFrequency: $paymentFrequency, startsOn: $startsOn, endsOn: $endsOn) {
+        mutation($id: ID, $clientId: ID, $name: String, $status: String, $cost: Float, $paymentFrequency: String, $fte: Float, $hours: Int, $startsOn: ISO8601Date, $endsOn: ISO8601Date) {
+          upsertProject(id: $id, clientId: $clientId, name: $name, status: $status, cost: $cost, paymentFrequency: $paymentFrequency, fte: $fte, hours: $hours, startsOn: $startsOn, endsOn: $endsOn) {
             id
             client {
               id
@@ -96,6 +96,8 @@ RSpec.describe Mutations::UpsertProject do
             name
             cost
             paymentFrequency
+            fte
+            hours
             status
             startsOn
             endsOn
@@ -119,6 +121,8 @@ RSpec.describe Mutations::UpsertProject do
           status: Project::COMPLETED,
           cost: 1000.00,
           paymentFrequency: Project::ANNUALLY,
+          fte: 1.25,
+          hours: 1_000,
           startsOn: starts_on = 2.weeks.from_now.to_date.iso8601,
           endsOn: ends_on = 10.weeks.from_now.to_date.iso8601
         }
@@ -131,6 +135,8 @@ RSpec.describe Mutations::UpsertProject do
       expect(post_result["status"]).to eq(Project::COMPLETED)
       expect(post_result["cost"]).to eq(1000.00)
       expect(post_result["paymentFrequency"]).to eq(Project::ANNUALLY)
+      expect(post_result["fte"]).to eq(1.25)
+      expect(post_result["hours"]).to eq(1_000)
       expect(post_result["startsOn"]).to eq(starts_on.to_s)
       expect(post_result["endsOn"]).to eq(ends_on.to_s)
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Project, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_inclusion_of(:status).in_array(Project::VALID_STATUSES) }
     it { should validate_numericality_of(:cost).is_greater_than_or_equal_to(0.0) }
+    it { should validate_numericality_of(:fte).is_greater_than_or_equal_to(0.0) }
+    it { should validate_numericality_of(:hours).is_greater_than_or_equal_to(0) }
     it { should validate_inclusion_of(:payment_frequency).in_array(%w(weekly monthly fortnightly quarterly annually)) }
   end
 


### PR DESCRIPTION
Closes https://github.com/goinvo/staffplan_redux/issues/155

Adds these fields to the database. Adds them to the GraphQL `Project` type, as well as the `upsertProject` mutation.

<img width="1084" alt="Screenshot 2024-04-04 at 9 57 01 PM" src="https://github.com/goinvo/staffplan_redux/assets/2804/0f30c422-1645-44aa-afa7-807ca2a6f204">
