### PR TITLE
Make starts_on and ends_on optional

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -33,14 +33,6 @@ class Assignment < ApplicationRecord
   end
 
   def starts_and_ends_on_rules
-    if starts_on.blank? && ends_on.present?
-      errors.add(:starts_on, "is required if an end date is set")
-    end
-
-    if ends_on.blank? && starts_on.present?
-      errors.add(:ends_on, "is required if a start date is set")
-    end
-
     return if starts_on.blank? || ends_on.blank?
 
     if starts_on > ends_on

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -30,18 +30,6 @@ RSpec.describe Assignment, type: :model do
       expect(assignment).to_not be_valid
       expect(assignment.errors[:ends_on]).to include("can't come before the assignment starts")
     end
-
-    it "does not allow ends_on to be set without starts_on" do
-      assignment = build(:assignment, starts_on: nil, ends_on: Date.today)
-      expect(assignment).to_not be_valid
-      expect(assignment.errors[:starts_on]).to include("is required if an end date is set")
-    end
-
-    it "does not allow starts_on to be set without ends_on" do
-      assignment = build(:assignment, starts_on: Date.today, ends_on: nil)
-      expect(assignment).to_not be_valid
-      expect(assignment.errors[:ends_on]).to include("is required if a start date is set")
-    end
   end
 
   describe "#project_and_user_belong_to_same_company" do


### PR DESCRIPTION
Closes #170 

Removes the backend validations on `Assignment#starts_on` and `Assignment#ends_on` being mutually required.