### PR TITLE
Optionally add assignments for projects when upserting

### DIFF
--- a/app/graphql/mutations/upsert_project.rb
+++ b/app/graphql/mutations/upsert_project.rb
@@ -15,6 +15,7 @@ module Mutations
     argument :hourly_rate, Integer, required: false, description: "The hourly rate for this project."
     argument :starts_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this project starts."
     argument :ends_on, GraphQL::Types::ISO8601Date, required: false, description: "The date this project ends."
+    argument :assignments, [Types::StaffPlan::AssignmentAttributes], required: false, description: "Assignments for this project. See upsertAssignment to create a single assignment for existing projects."
 
     # return type from the mutation
     type Types::StaffPlan::ProjectType, null: true
@@ -31,7 +32,8 @@ module Mutations
       rate_type: nil,
       hourly_rate: nil,
       starts_on: nil,
-      ends_on: nil
+      ends_on: nil,
+      assignments: []
     )
       current_company = context[:current_company]
 
@@ -68,6 +70,10 @@ module Mutations
 
       if project.valid?
         project.save!
+
+        assignments.map do |assignment|
+          project.assignments << Assignment.new(assignment.to_h)
+        end
       else
         project.errors.group_by_attribute.each do |attribute, errors|
           errors.each do |error|

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -38,6 +38,41 @@ type Assignment {
   workWeeks: [WorkWeek!]!
 }
 
+"""
+Attributes for creating an assignment
+"""
+input AssignmentAttributes {
+  """
+  The date the assignment ends
+  """
+  endsOn: ISO8601Date
+
+  """
+  The estimated weekly hours for this assignment
+  """
+  estimatedWeeklyHours: Int
+
+  """
+  The project this assignment is for
+  """
+  projectId: ID
+
+  """
+  The date the assignment starts
+  """
+  startsOn: ISO8601Date
+
+  """
+  The status of the assignment
+  """
+  status: String
+
+  """
+  The user assigned to this assignment
+  """
+  userId: ID
+}
+
 enum AssignmentStatus {
   """
   The assignment is currently in progress.
@@ -181,6 +216,11 @@ type Mutation {
   Create or update a project.
   """
   upsertProject(
+    """
+    Assignments for this project. See upsertAssignment to create a single assignment for existing projects.
+    """
+    assignments: [AssignmentAttributes!]
+
     """
     The ID of the client for this project.
     """

--- a/app/graphql/types/staff_plan/assignment_attributes.rb
+++ b/app/graphql/types/staff_plan/assignment_attributes.rb
@@ -1,0 +1,10 @@
+class Types::StaffPlan::AssignmentAttributes < Types::BaseInputObject
+  description "Attributes for creating an assignment"
+
+  argument :user_id, ID, required: false, description: "The user assigned to this assignment"
+  argument :project_id, ID, required: false, description: "The project this assignment is for"
+  argument :status, String, required: false, description: "The status of the assignment"
+  argument :starts_on, GraphQL::Types::ISO8601Date, required: false, description: "The date the assignment starts"
+  argument :ends_on, GraphQL::Types::ISO8601Date, required: false, description: "The date the assignment ends"
+  argument :estimated_weekly_hours, Integer, required: false, description: "The estimated weekly hours for this assignment"
+end


### PR DESCRIPTION
Adds an optional way to create assignments for a project when upserting.

Side note: existing mutations should probably be refactored to use input objects. I think that would result in a cleaner set of args to mutations while keeping the input validation logic with GraphQL.