### PR TITLE
Removes uniqueness constraint for company names.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    paper_trail (15.1.0)
+    paper_trail (15.2.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
     passwordless (1.7.0)
@@ -268,7 +268,7 @@ GEM
     regexp_parser (2.9.0)
     reline (0.5.9)
       io-console (~> 0.5)
-    request_store (1.6.0)
+    request_store (1.7.0)
       rack (>= 1.4)
     rexml (3.3.6)
       strscan

--- a/db/migrate/20240908194832_make_company_name_not_unique.rb
+++ b/db/migrate/20240908194832_make_company_name_not_unique.rb
@@ -1,0 +1,5 @@
+class MakeCompanyNameNotUnique < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :companies, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_24_013820) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_08_194832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,7 +70,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_24_013820) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "stripe_id"
-    t.index ["name"], name: "index_companies_on_name", unique: true
   end
 
   create_table "memberships", force: :cascade do |t|


### PR DESCRIPTION
Previously we had a unique index on company names. It was an arbitrary decision I'd made without much thought to the implications and its value. I'm relaxing that for now unless we have a good reason to bring it back