### PR TITLE
Tidier work week management

### DIFF
--- a/app/graphql/mutations/upsert_work_week.rb
+++ b/app/graphql/mutations/upsert_work_week.rb
@@ -27,11 +27,18 @@ module Mutations
       work_week = current_company.work_weeks.find_by(assignment_id:, cweek:, year:)
 
       if work_week.blank?
-        # create it
+        # create it. unable to do this through current_company.work_weeks becaues it goes through more than one other association
         work_week = WorkWeek.create!(assignment_id:, cweek:, year:)
       end
 
-      work_week.update!(estimated_hours:, actual_hours:)
+      if work_week.is_future_work_week? && (
+        estimated_hours.blank? || estimated_hours.zero?
+      )
+        # the front end will send nil or 0 values for work weeks that should be deleted
+        work_week.destroy
+      else
+        work_week.update(estimated_hours: estimated_hours.to_i, actual_hours: actual_hours.to_i)
+      end
 
       work_week
     end

--- a/app/graphql/mutations/upsert_work_weeks.rb
+++ b/app/graphql/mutations/upsert_work_weeks.rb
@@ -30,7 +30,12 @@ module Mutations
             # the front end will send nil or 0 values for work weeks that should be deleted
             work_week.destroy
           else
-            work_week.update(ww.to_h.slice(:estimated_hours, :actual_hours))
+            values = ww.to_h.slice(:estimated_hours, :actual_hours).tap do |v|
+              v[:estimated_hours] = v[:estimated_hours].to_i
+              v[:actual_hours] = v[:actual_hours].to_i
+            end
+
+            work_week.update(values)
           end
         end
       end

--- a/app/graphql/mutations/upsert_work_weeks.rb
+++ b/app/graphql/mutations/upsert_work_weeks.rb
@@ -24,7 +24,10 @@ module Mutations
         work_weeks.each do |ww|
           work_week = assignment.work_weeks.find_or_initialize_by(cweek: ww.cweek, year: ww.year)
 
-          if ww.estimated_hours.blank? || ww.estimated_hours.zero?
+          if work_week.is_future_work_week? && (
+            ww.estimated_hours.blank? || ww.estimated_hours.zero?
+          )
+            # the front end will send nil or 0 values for work weeks that should be deleted
             work_week.destroy
           else
             work_week.update(ww.to_h.slice(:estimated_hours, :actual_hours))

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -13,6 +13,12 @@ class WorkWeek < ApplicationRecord
   validates :actual_hours, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 168 }
   validate :no_future_actual_hours
 
+  def is_future_work_week?
+    Date.today.year < year || (
+      year == Date.today.year && cweek > Date.today.cweek
+    )
+  end
+
   private
 
   def no_future_actual_hours

--- a/spec/graphql/mutations/upsert_work_week_spec.rb
+++ b/spec/graphql/mutations/upsert_work_week_spec.rb
@@ -80,6 +80,94 @@ RSpec.describe Mutations::UpsertWorkWeek do
       expect(post_result["estimatedHours"]).to eq(20)
     end
 
+    it "deletes a future work week when passed a null or 0 value for estimatedHours" do
+      query_string = <<-GRAPHQL
+        mutation($assignmentId: ID!, $cweek: Int!, $year: Int!, $actualHours: Int, $estimatedHours: Int) {
+          upsertWorkWeek(assignmentId: $assignmentId, cweek: $cweek, year: $year, actualHours: $actualHours, estimatedHours: $estimatedHours) {
+            actualHours
+            estimatedHours
+          }
+        }
+      GRAPHQL
+
+      company = create(:company)
+      assignment = tbd_assignment_for_company(company:)
+      user = company.users.first
+      work_week = create(:work_week,
+        cweek: (Date.today + 1.month).cweek,
+        year: (Date.today + 1.month).year,
+        estimated_hours: 10,
+        actual_hours: 0,
+        assignment:
+      )
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: work_week.company
+        },
+        variables: {
+          assignmentId: work_week.assignment_id,
+          cweek: work_week.cweek,
+          year: work_week.year,
+          actualHours: 0,
+          estimatedHours: nil
+        }
+      )
+
+      post_result = result["data"]["upsertWorkWeek"]
+      expect(post_result["actualHours"]).to eq(0)
+      expect(post_result["estimatedHours"]).to eq(10)
+      expect {
+        work_week.reload
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "does not delete a future work week when passed a null or 0 value for estimatedHours" do
+      query_string = <<-GRAPHQL
+        mutation($assignmentId: ID!, $cweek: Int!, $year: Int!, $actualHours: Int, $estimatedHours: Int) {
+          upsertWorkWeek(assignmentId: $assignmentId, cweek: $cweek, year: $year, actualHours: $actualHours, estimatedHours: $estimatedHours) {
+            actualHours
+            estimatedHours
+          }
+        }
+      GRAPHQL
+
+      company = create(:company)
+      assignment = tbd_assignment_for_company(company:)
+      user = company.users.first
+      work_week = create(:work_week,
+        cweek: (Date.today - 1.month).cweek,
+        year: (Date.today - 1.month).year,
+        estimated_hours: 10,
+        actual_hours: 10,
+        assignment:
+      )
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: work_week.company
+        },
+        variables: {
+          assignmentId: work_week.assignment_id,
+          cweek: work_week.cweek,
+          year: work_week.year,
+          actualHours: 0,
+          estimatedHours: nil
+        }
+      )
+
+      post_result = result["data"]["upsertWorkWeek"]
+      expect(post_result["actualHours"]).to eq(0)
+      expect(post_result["estimatedHours"]).to eq(0)
+      expect {
+        work_week.reload
+      }.to_not raise_error
+    end
+
     it "fails if the assignment is not found" do
       query_string = <<-GRAPHQL
         mutation($assignmentId: ID!, $cweek: Int!, $year: Int!) {

--- a/spec/graphql/mutations/upsert_work_week_spec.rb
+++ b/spec/graphql/mutations/upsert_work_week_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Mutations::UpsertWorkWeek do
           assignmentId: work_week.assignment_id,
           cweek: work_week.cweek,
           year: work_week.year,
-          actualHours: 0,
+          actualHours: nil,
           estimatedHours: nil
         }
       )

--- a/spec/graphql/mutations/upsert_work_weeks_spec.rb
+++ b/spec/graphql/mutations/upsert_work_weeks_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe Mutations::UpsertWorkWeeks do
         expect(post_result.map { |pr| pr["cweek"] }).to eq([
           updated_work_weeks[0][:cweek], updated_work_weeks[3][:cweek], updated_work_weeks[4][:cweek]
         ])
+        expect(post_result.find { |pr| pr["cweek"] == updated_work_weeks[0][:cweek] }["estimatedHours"]).to eq(0)
       end
     end
 

--- a/spec/graphql/mutations/upsert_work_weeks_spec.rb
+++ b/spec/graphql/mutations/upsert_work_weeks_spec.rb
@@ -116,6 +116,60 @@ RSpec.describe Mutations::UpsertWorkWeeks do
       end
     end
 
+    it "prunes existing work weeks when passed null or empty values for estimatedHours" do
+      query_string = <<-GRAPHQL
+        mutation($assignmentId: ID!, $workWeeks: [WorkWeeksInputObject!]!) {
+          upsertWorkWeeks(assignmentId: $assignmentId, workWeeks: $workWeeks) {
+            workWeeks {
+              cweek
+              year
+              actualHours
+              estimatedHours
+            }          
+          }
+        }
+      GRAPHQL
+
+      company = create(:company)
+      assignment = tbd_assignment_for_company(company:)
+      user = company.users.first
+      work_weeks = 5.times.map do |i|
+        date = Date.today - i.weeks
+        create(:work_week, :blank, assignment:, cweek: date.cweek, year: date.year)
+      end
+
+      updated_work_weeks = work_weeks.map.with_index do |week, i|
+        {
+          cweek: week.cweek,
+          year: week.year,
+          actualHours: i * 5,
+          estimatedHours: i * 6
+        }
+      end
+
+      # set the estimated hours to nil for the first work week
+      updated_work_weeks.first[:estimatedHours] = nil
+
+      # set the estimated hours to 0 for the second work week
+      updated_work_weeks.second[:estimatedHours] = 0
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: company
+        },
+        variables: {
+          assignmentId: assignment.id,
+          workWeeks: updated_work_weeks
+        }
+      )
+
+      post_result = result["data"]["upsertWorkWeeks"]["workWeeks"]
+      expect(post_result.length).to eq(3)
+      expect(post_result.map { |pr| pr["cweek"] }).to eq(updated_work_weeks[2..-1].map { |ww| ww[:cweek] })
+    end
+
     it "fails if the assignment is not found" do
       query_string = <<-GRAPHQL
         mutation($assignmentId: ID!, $workWeeks: [WorkWeeksInputObject!]!) {

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe WorkWeek, type: :model do
     it { should have_one(:user) }
     it { should have_one(:project) }
   end
+
+  context "#is_future_work_week?" do
+    it "returns true if the work week is in the future" do
+      work_week = build(:work_week, year: Date.today.year, cweek: Date.today.cweek + 1)
+      expect(work_week.is_future_work_week?).to be_truthy
+    end
+
+    it "returns false if the work week is in the past" do
+      work_week = build(:work_week, year: Date.today.year, cweek: Date.today.cweek - 1)
+      expect(work_week.is_future_work_week?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Addresses https://github.com/goinvo/staffplan_redux/issues/340. tl;dr: for `upserWorkWeek` and `upsertWorkWeeks`:

* future work weeks where `estimatedHours` are passed as `nil` or `0` will be deleted from the database since there's no reason to track them
* past and current weeks getting `nil` or `0` values will have `actualHours` and `estimatedHours` set to 0 (we might want to consider blocking the setting of a past weeks' estimatedHours 🤷🏻)