### PR TITLE
Adds user#isActive attribute

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -619,6 +619,11 @@ type User {
   currentCompany: Company
   email: String!
   id: ID!
+
+  """
+  Whether the user is an active member of the current company.
+  """
+  isActive: Boolean!
   name: String!
 
   """

--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -36,6 +36,11 @@ module Types
         object.role(company: object.current_company)
       end
 
+      field :is_active, Boolean, null: false, description: "Whether the user is an active member of the current company."
+      def is_active
+        object.status(company: object.current_company) == Membership::ACTIVE
+      end
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,10 @@ class User < ApplicationRecord
     memberships.find_by(company:).role
   end
 
+  def status(company:)
+    memberships.find_by(company:).status
+  end
+
   def inactive?(company:)
     memberships.find_by(company:).inactive?
   end

--- a/spec/graphql/query_type_spec.rb
+++ b/spec/graphql/query_type_spec.rb
@@ -63,4 +63,56 @@ RSpec.describe "QueryType" do
       expect(assignment["canBeDeleted"]).to eq(true)
     end
   end
+
+  context "user#isActive" do
+    it "is true if the user is an active member of the company" do
+      query_string = <<-GRAPHQL
+        query {
+          viewer {
+            isActive
+          }
+        }
+      GRAPHQL
+
+      user = create(:membership).user
+      company = user.current_company
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: company
+        }
+      )
+
+      user = result["data"]["viewer"]
+      expect(result["errors"]).to be_nil
+      expect(user["isActive"]).to eq(true)
+    end
+
+    it "is false if the user is not an active member of the company" do
+      query_string = <<-GRAPHQL
+        query {
+          viewer {
+            isActive
+          }
+        }
+      GRAPHQL
+
+      user = create(:membership, status: Membership::INACTIVE).user
+      company = user.current_company
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: company
+        }
+      )
+
+      user = result["data"]["viewer"]
+      expect(result["errors"]).to be_nil
+      expect(user["isActive"]).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
In support of https://github.com/goinvo/staffplan-next-app/issues/435, adds a User#isActive property that can be used to show whether a user is active or inactive in the SP UI.