### PR TITLE
Update nav to match React app more closely

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+.font-open-sans {
+    font-family: "Open Sans", serif;
+    font-optical-sizing: auto;
+    font-weight: 300;
+    font-style: normal;
+    font-variation-settings: normal;
+}
+
 /*
 
 @layer components {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,6 +10,12 @@
     font-variation-settings: normal;
 }
 
+@layer utilities {
+    .text-tiffany {
+        color: rgb(39 181 176 / var(--tw-text-opacity, 1));
+    }
+}
+
 /*
 
 @layer components {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
   def header_link_to(text, path)
     css_classes = if current_page?(path) || request.url.match(path) != nil
-      "bg-gray-900 text-white rounded-md px-3 py-2 text-sm font-medium"
+      "bg-gray-900 text-white rounded-md px-3 py-2 text-md font-medium"
     else
-      "text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
+      "text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-md font-medium"
     end
 
     link_to text, path, class: css_classes

--- a/app/javascript/controllers/desktop_nav_controller.js
+++ b/app/javascript/controllers/desktop_nav_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="mobile-nav"
+export default class extends Controller {
+  static targets = ['open', 'close']
+  static values = { open: Boolean, default: false }
+
+  openValueChanged() {
+    if (this.openValue === true) {
+      this.show()
+    } else {
+      this.hide()
+    }
+  }
+
+  show() {
+    document.getElementById('desktop-menu').classList.replace('hidden', 'absolute')
+    this.openValue = true;
+  }
+
+  hide() {
+    document.getElementById('desktop-menu').classList.replace('absolute', 'hidden')
+    this.openValue = false
+  }
+
+  toggle() {
+    this.openValue = !this.openValue
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
-<html class="h-full bg-gray-100">
+<html class="h-full bg-gray-100 font-open-sans">
   <head>
     <title>staffplan.com</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= favicon_link_tag image_path("favicon.ico") %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
@@ -13,104 +16,7 @@
 
   <body class="h-full">
     <div class="min-h-full">
-      <nav class="bg-gray-800">
-        <div class="mx-auto">
-          <div class="flex h-16 items-center justify-between">
-            <div class="flex items-center">
-              <div class="hidden md:block">
-                <div class="ml-10 flex items-baseline space-x-4">
-                  <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-                  <% if Rails.env.production? %>
-                    <a href="https://ui.staffplan.com/people/<%= current_user.id %>" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">My StaffPlan</a>
-                  <% else %>
-                    <%= header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
-                  <% end %>
-                  <% if Rails.env.production? %>
-                    <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">Projects</a>
-                  <% else %>
-                    <%= header_link_to "Projects", "http://localhost:8080/projects" %>
-                  <% end %>
-                  <% if Rails.env.production? %>
-                    <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">People</a>
-                  <% else %>
-                    <%= header_link_to "People", "http://localhost:8080/people" %>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-            <div class="hidden md:block">
-              <div class="ml-4 flex items-center md:ml-6">
-                <%= header_link_to "Open Source", "https://github.com/goinvo/staffplan-next-app" %>
-                <%= link_to 'Settings', settings_profile_path, class: 'text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium' %>
-                <%= button_to("Sign out", auth_sign_out_url, method: :delete, class: "px-6 relative rounded-full bg-gray-800 p-1 text-white hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800") %>
-              </div>
-            </div>
-            <div class="-mr-2 flex md:hidden">
-              <!-- Mobile menu button -->
-              <div data-controller="mobile-nav" data-action="click->mobile-nav#toggle">
-                <button data-mobile-nav-target="button" type="button" class="relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" aria-controls="mobile-menu" aria-expanded="false">
-                  <span class="absolute -inset-0.5"></span>
-                  <span class="sr-only">Open main menu</span>
-                  <!-- Menu open: "hidden", Menu closed: "block" -->
-                  <svg data-mobile-nav-target="open" class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-                  </svg>
-                  <!-- Menu open: "block", Menu closed: "hidden" -->
-                  <svg data-mobile-nav-target="close" class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Mobile menu, show/hide based on menu state. -->
-        <div class="border-b border-gray-700 md:hidden hidden" id="mobile-menu">
-          <div class="space-y-1 px-2 py-3 sm:px-3">
-            <% if Rails.env.production? %>
-              <a href="https://ui.staffplan.com/people/<%= current_user.id  %>" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">My StaffPlan</a>
-            <% else %>
-              <%= mobile_header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
-            <% end %>
-            <% if Rails.env.production? %>
-              <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Projects</a>
-            <% else %>
-              <%= mobile_header_link_to "Projects", "http://localhost:8080/projects" %>
-            <% end %>
-            <% if Rails.env.production? %>
-              <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">People</a>
-            <% else %>
-              <%= mobile_header_link_to "People", "http://localhost:8080/people" %>
-            <% end %>
-            <% if current_user.owner?(company: current_company) || current_user.admin?(company: current_company) %>
-              <%= mobile_header_link_to "Settings", settings_path %>
-            <% end %>
-          </div>
-          <div class="border-t border-gray-700 pb-3 pt-4">
-            <div class="flex items-center px-5">
-              <div class="flex-shrink-0">
-                <%= image_tag(AvatarHelper.new(target: current_user).image_url, class: "h-10 w-10 rounded-full") %>
-              </div>
-              <div class="ml-3">
-                <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>
-                <div class="text-sm font-medium leading-none text-gray-400"><%= current_user.email %></div>
-              </div>
-              <button type="button" class="relative ml-auto flex-shrink-0 rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
-                <span class="absolute -inset-1.5"></span>
-                <span class="sr-only">View notifications</span>
-                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
-                </svg>
-              </button>
-            </div>
-            <div class="mt-3 space-y-1 px-2">
-              <%= button_to("Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white") %>
-              <%#= link_to "Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white" %>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <%= render "shared/nav" %>
 
       <% if content_for(:header) %>
         <header class="bg-white shadow">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= favicon_link_tag image_path("favicon.ico") %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,0 +1,98 @@
+<nav class="bg-gray-800">
+  <div class="mx-auto">
+    <div class="flex h-14 items-center justify-between">
+      <div class="flex items-center">
+        <div class="hidden md:block">
+          <div class="ml-10 flex items-baseline space-x-4">
+            <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
+            <% if Rails.env.production? %>
+              <a href="https://ui.staffplan.com/people/<%= current_user.id %>" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-md font-medium">My StaffPlan</a>
+            <% else %>
+              <%= header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
+            <% end %>
+            <% if Rails.env.production? %>
+              <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">Projects</a>
+            <% else %>
+              <%= header_link_to "Projects", "http://localhost:8080/projects" %>
+            <% end %>
+            <% if Rails.env.production? %>
+              <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">People</a>
+            <% else %>
+              <%= header_link_to "People", "http://localhost:8080/people" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="hidden md:block">
+        <div class="ml-4 flex items-center md:ml-6">
+          <%= header_link_to "Open Source", "https://github.com/goinvo/staffplan-next-app" %>
+          <%= link_to 'Settings', settings_profile_path, class: 'text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium' %>
+          <%= button_to("Sign out", auth_sign_out_url, method: :delete, class: "px-6 relative rounded-full bg-gray-800 p-1 text-white hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800") %>
+        </div>
+      </div>
+      <div class="-mr-2 flex md:hidden">
+        <!-- Mobile menu button -->
+        <div data-controller="mobile-nav" data-action="click->mobile-nav#toggle">
+          <button data-mobile-nav-target="button" type="button" class="relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" aria-controls="mobile-menu" aria-expanded="false">
+            <span class="absolute -inset-0.5"></span>
+            <span class="sr-only">Open main menu</span>
+            <!-- Menu open: "hidden", Menu closed: "block" -->
+            <svg data-mobile-nav-target="open" class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+            <!-- Menu open: "block", Menu closed: "hidden" -->
+            <svg data-mobile-nav-target="close" class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile menu, show/hide based on menu state. -->
+  <div class="border-b border-gray-700 md:hidden hidden" id="mobile-menu">
+    <div class="space-y-1 px-2 py-3 sm:px-3">
+      <% if Rails.env.production? %>
+        <a href="https://ui.staffplan.com/people/<%= current_user.id  %>" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">My StaffPlan</a>
+      <% else %>
+        <%= mobile_header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
+      <% end %>
+      <% if Rails.env.production? %>
+        <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Projects</a>
+      <% else %>
+        <%= mobile_header_link_to "Projects", "http://localhost:8080/projects" %>
+      <% end %>
+      <% if Rails.env.production? %>
+        <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">People</a>
+      <% else %>
+        <%= mobile_header_link_to "People", "http://localhost:8080/people" %>
+      <% end %>
+      <% if current_user.owner?(company: current_company) || current_user.admin?(company: current_company) %>
+        <%= mobile_header_link_to "Settings", settings_path %>
+      <% end %>
+    </div>
+    <div class="border-t border-gray-700 pb-3 pt-4">
+      <div class="flex items-center px-5">
+        <div class="flex-shrink-0">
+          <%= image_tag(AvatarHelper.new(target: current_user).image_url, class: "h-10 w-10 rounded-full") %>
+        </div>
+        <div class="ml-3">
+          <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>
+          <div class="text-sm font-medium leading-none text-gray-400"><%= current_user.email %></div>
+        </div>
+        <button type="button" class="relative ml-auto flex-shrink-0 rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
+          <span class="absolute -inset-1.5"></span>
+          <span class="sr-only">View notifications</span>
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+          </svg>
+        </button>
+      </div>
+      <div class="mt-3 space-y-1 px-2">
+        <%= button_to("Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white") %>
+        <%#= link_to "Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white" %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -11,26 +11,45 @@
               <%= header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
             <% end %>
             <% if Rails.env.production? %>
-              <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">Projects</a>
-            <% else %>
-              <%= header_link_to "Projects", "http://localhost:8080/projects" %>
-            <% end %>
-            <% if Rails.env.production? %>
               <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">People</a>
             <% else %>
               <%= header_link_to "People", "http://localhost:8080/people" %>
+            <% end %>
+            <% if Rails.env.production? %>
+              <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium">Projects</a>
+            <% else %>
+              <%= header_link_to "Projects", "http://localhost:8080/projects" %>
             <% end %>
           </div>
         </div>
       </div>
       <div class="hidden md:block">
-        <div class="ml-4 flex items-center md:ml-6">
-          <%= header_link_to "Open Source", "https://github.com/goinvo/staffplan-next-app" %>
-          <%= link_to 'Settings', settings_profile_path, class: 'text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium' %>
-          <%= button_to("Sign out", auth_sign_out_url, method: :delete, class: "px-6 relative rounded-full bg-gray-800 p-1 text-white hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800") %>
+        <div data-controller="desktop-nav" class="ml-4 flex items-center md:ml-6 relative">
+          <%= link_to "Feedback", "mailto:staffplan@goinvo.com", class: 'text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium' %>
+          <!-- desktop three dot menu -->
+          <div data-action="click->desktop-nav#toggle">
+            <button data-mobile-nav-target="button" type="button" class="relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:text-white" aria-controls="mobile-menu" aria-expanded="false">
+              <span class="absolute -inset-0.5"></span>
+              <span class="sr-only">Open main menu</span>
+              <!-- Menu open: "hidden", Menu closed: "block" -->
+              <svg data-desktop-nav-target="open" class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="#aaa" viewBox="0 0 256 256">
+                  <path d="M140,128a12,12,0,1,1-12-12A12,12,0,0,1,140,128ZM128,72a12,12,0,1,0-12-12A12,12,0,0,0,128,72Zm0,112a12,12,0,1,0,12,12A12,12,0,0,0,128,184Z"></path>
+                </svg>
+              </svg>
+            </button>
+          </div>
+          <div class="hidden right-10 top-2 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none" role="menu" id="desktop-menu">
+            <div class="py-1 z-20 relative" role="none">
+              <%= link_to "Open Source", "https://github.com/goinvo/staffplan-next-app", class: "block px-4 py-2 text-sm text-gray-700 hover:text-tiffany" %>
+              <%= link_to 'Settings', settings_profile_path, class: 'block px-4 py-2 text-sm text-gray-700 hover:text-tiffany' %>
+              <%= button_to("Sign out", auth_sign_out_url, method: :delete, class: "block px-4 py-2 text-sm text-gray-700 hover:text-tiffany") %>
+            </div>
+            <div class="fixed inset-0 z-0" data-desktop-nav-target="close" data-action="click->desktop-nav#toggle"></div>
+          </div>
         </div>
       </div>
-      <div class="-mr-2 flex md:hidden">
+      <div class="mr-2 flex md:hidden">
         <!-- Mobile menu button -->
         <div data-controller="mobile-nav" data-action="click->mobile-nav#toggle">
           <button data-mobile-nav-target="button" type="button" class="relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" aria-controls="mobile-menu" aria-expanded="false">
@@ -59,39 +78,25 @@
         <%= mobile_header_link_to "My StaffPlan", "http://localhost:8080/people/#{current_user.id}" %>
       <% end %>
       <% if Rails.env.production? %>
-        <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Projects</a>
-      <% else %>
-        <%= mobile_header_link_to "Projects", "http://localhost:8080/projects" %>
-      <% end %>
-      <% if Rails.env.production? %>
         <a href="https://ui.staffplan.com/people" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">People</a>
       <% else %>
         <%= mobile_header_link_to "People", "http://localhost:8080/people" %>
+      <% end %>
+      <% if Rails.env.production? %>
+        <a href="https://ui.staffplan.com/projects" class="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Projects</a>
+      <% else %>
+        <%= mobile_header_link_to "Projects", "http://localhost:8080/projects" %>
       <% end %>
       <% if current_user.owner?(company: current_company) || current_user.admin?(company: current_company) %>
         <%= mobile_header_link_to "Settings", settings_path %>
       <% end %>
     </div>
     <div class="border-t border-gray-700 pb-3 pt-4">
-      <div class="flex items-center px-5">
-        <div class="flex-shrink-0">
-          <%= image_tag(AvatarHelper.new(target: current_user).image_url, class: "h-10 w-10 rounded-full") %>
-        </div>
-        <div class="ml-3">
-          <div class="text-base font-medium leading-none text-white"><%= current_user.name %></div>
-          <div class="text-sm font-medium leading-none text-gray-400"><%= current_user.email %></div>
-        </div>
-        <button type="button" class="relative ml-auto flex-shrink-0 rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
-          <span class="absolute -inset-1.5"></span>
-          <span class="sr-only">View notifications</span>
-          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
-          </svg>
-        </button>
-      </div>
       <div class="mt-3 space-y-1 px-2">
+        <%= link_to "Feedback", "mailto:staffplan@goinvo.com", class: 'block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white' %>
+        <%= link_to "Open Source", "https://github.com/goinvo/staffplan-next-app", class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white" %>
+        <%= link_to 'Settings', settings_profile_path, class: 'block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white' %>
         <%= button_to("Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white") %>
-        <%#= link_to "Sign out", auth_sign_out_path, data: {method: :delete}, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
tl;dr: updates the Rails app / nav to more closely match the React app. Notable changes:

* changed to Open Sans font
* rearranged nav menu options
* put OSS / feedback / sign out links under a floating nav similar to the React app

It's not 100% pixel perfect, but hopefully looks close enough for now 🙏🏻 Addresses stuff in https://github.com/goinvo/staffplan_redux/issues/423 and https://github.com/goinvo/staffplan_redux/issues/319