### PR TITLE
Adds assignments.focused to allow users to decide what assignments/projects should be visible on their My StaffPlan view

### DIFF
--- a/app/graphql/mutations/upsert_assignment.rb
+++ b/app/graphql/mutations/upsert_assignment.rb
@@ -11,6 +11,8 @@ module Mutations
              description: "The ID of the user being assigned to the project. If omitted, the assignment status cannot be 'active'."
     argument :status, String, required: true,
              description: "The status of the assignment."
+    argument :focused, Boolean, required: false,
+              description: "Should this assignment be rendered by default on the assignee's StaffPlan. Can only be updated by the assignee."
     argument :estimated_weekly_hours, Integer, required: false,
              description: "The estimated weekly hours for this assignment."
     argument :starts_on, GraphQL::Types::ISO8601Date, required: false,
@@ -21,8 +23,9 @@ module Mutations
     # return type from the mutation
     type Types::StaffPlan::AssignmentType
 
-    def resolve(id: nil, project_id:, user_id: nil, status:, estimated_weekly_hours: nil, starts_on: nil, ends_on: nil)
+    def resolve(id: nil, project_id:, user_id: nil, status:, focused: nil, estimated_weekly_hours: nil, starts_on: nil, ends_on: nil)
       current_company = context[:current_company]
+      current_user = context[:current_user]
 
       # try and find the assignment
       assignment = if id.present?
@@ -36,6 +39,7 @@ module Mutations
         assignment = project.assignments.new(user_id:, status:)
       end
 
+      assignment.assign_attributes(focused:) if !focused.nil? && current_user == assignment.user
       assignment.assign_attributes(estimated_weekly_hours: estimated_weekly_hours) if estimated_weekly_hours
       assignment.assign_attributes(starts_on: starts_on) if starts_on
       assignment.assign_attributes(ends_on: ends_on) if ends_on

--- a/app/graphql/mutations/upsert_assignment.rb
+++ b/app/graphql/mutations/upsert_assignment.rb
@@ -33,12 +33,13 @@ module Mutations
       end
 
       if assignment
-        assignment.assign_attributes(project_id:, user_id:, status:)
+        assignment.assign_attributes(project_id:, status:)
       else
         project = current_company.projects.find(project_id)
         assignment = project.assignments.new(user_id:, status:)
       end
 
+      assignment.assign_attributes(user_id:) if user_id
       assignment.assign_attributes(focused:) if !focused.nil? && current_user == assignment.user
       assignment.assign_attributes(estimated_weekly_hours: estimated_weekly_hours) if estimated_weekly_hours
       assignment.assign_attributes(starts_on: starts_on) if starts_on

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -19,6 +19,11 @@ type Assignment {
   The estimated weekly hours for this assignment
   """
   estimatedWeeklyHours: Int
+
+  """
+  Should this assignemnt be rendered by default on the assignee's StaffPlan
+  """
+  focused: Boolean!
   id: ID!
 
   """
@@ -215,6 +220,11 @@ type Mutation {
     The estimated weekly hours for this assignment.
     """
     estimatedWeeklyHours: Int
+
+    """
+    Should this assignment be rendered by default on the assignee's StaffPlan. Can only be updated by the assignee.
+    """
+    focused: Boolean
 
     """
     The ID of the assignment to update.

--- a/app/graphql/types/staff_plan/assignment_type.rb
+++ b/app/graphql/types/staff_plan/assignment_type.rb
@@ -16,6 +16,7 @@ module Types
       field :ends_on, GraphQL::Types::ISO8601Date, null: true, description: 'The date the assignment ends'
       field :estimated_weekly_hours, Integer, null: true, description: 'The estimated weekly hours for this assignment'
       field :can_be_deleted, Boolean, null: false, description: 'Whether the assignment can be deleted'
+      field :focused, Boolean, null: false, description: "Should this assignemnt be rendered by default on the assignee's StaffPlan"
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/db/migrate/20250120190255_add_assignment_focused.rb
+++ b/db/migrate/20250120190255_add_assignment_focused.rb
@@ -1,0 +1,5 @@
+class AddAssignmentFocused < ActiveRecord::Migration[8.0]
+  def change
+    add_column :assignments, :focused, :boolean, default: true, null: false
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,4 +1,19 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
@@ -6,24 +21,24 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
@@ -37,17 +52,17 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
@@ -59,9 +74,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "metadata"
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
@@ -69,9 +84,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
@@ -79,8 +94,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "task_key", null: false
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
@@ -95,8 +110,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
@@ -105,8 +120,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
@@ -115,9 +130,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_09_08_194832) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_20_190255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_08_194832) do
     t.date "starts_on"
     t.date "ends_on"
     t.integer "estimated_weekly_hours"
+    t.boolean "focused", default: true, null: false
     t.index ["project_id"], name: "index_assignments_on_project_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -69,6 +69,7 @@ FactoryBot.define do
       skip_user { false }
     end
     status { Assignment::ACTIVE }
+    focused { true }
 
     after(:build) do |assignment, evaluator|
       if assignment.user.blank? && evaluator.skip_user.blank?


### PR DESCRIPTION
Implements the backend that should be needed for https://github.com/goinvo/staffplan-next-app/issues/437

Adds a new field to the `AssignmentType`, `focused`. Default: true, this value should be used by the front end to either render a row for the assignment on the person's My StaffPlan / `/projects/#` URL that corresponds to their user.

When `true`, the row should be rendered. When `false`, the row should not be rendered and should have its hours aggregated at the bottom of the page as in @ericbenwa's designs.