### PR TITLE
Move existing Sidekiq jobs to SolidQueue

### DIFF
--- a/app/commands/add_user_to_company.rb
+++ b/app/commands/add_user_to_company.rb
@@ -50,6 +50,6 @@ class AddUserToCompany
   end
 
   def update_stripe_subscription_count
-    SyncCustomerSubscriptionJob.perform_async(@company.id)
+    Stripe::SyncCustomerSubscriptionJob.perform_later(@company)
   end
 end

--- a/app/commands/create_new_company.rb
+++ b/app/commands/create_new_company.rb
@@ -35,7 +35,7 @@ class CreateNewCompany
   end
 
   def enqueue_create_stripe_customer_job
-    CreateStripeCustomerJob.perform_async(@company.id)
+    Stripe::CreateCustomerJob.perform_later(@company)
   end
 
   def claim_registration

--- a/app/jobs/stripe/create_customer_job.rb
+++ b/app/jobs/stripe/create_customer_job.rb
@@ -3,7 +3,6 @@ module Stripe
     queue_as :default
     self.queue_adapter = :solid_queue
 
-
     def perform(company)
       owner = company.memberships.find_by!(role: 'owner').user
 

--- a/app/jobs/stripe/create_customer_job.rb
+++ b/app/jobs/stripe/create_customer_job.rb
@@ -1,0 +1,45 @@
+module Stripe
+  class CreateCustomerJob < ApplicationJob
+    queue_as :default
+    self.queue_adapter = :solid_queue
+
+
+    def perform(company)
+      owner = company.memberships.find_by!(role: 'owner').user
+
+      if company.stripe_id.blank?
+        stripe_customer = Stripe::Customer.create(
+          {
+            name: "#{company.name} | #{owner.name}",
+            email: owner.email,
+          }
+        )
+
+        company.update(stripe_id: stripe_customer.id)
+      end
+
+      if company.subscription.stripe_id.blank?
+        # create base subscription
+        stripe_subscription = Stripe::Subscription.create(
+          {
+            customer: company.stripe_id,
+            items: [{
+              price: Rails.application.credentials.stripe_price_id,
+              quantity: company.memberships.active.count
+            }],
+            trial_period_days: 30,
+            trial_settings: {
+              end_behavior: {
+                missing_payment_method: "cancel"
+              }
+            },
+            payment_settings: {
+              save_default_payment_method: 'on_subscription',
+            }
+          })
+        company.subscription.update(stripe_id: stripe_subscription.id)
+      end
+    end
+  end
+
+end

--- a/app/jobs/stripe/sync_customer_subscription_job.rb
+++ b/app/jobs/stripe/sync_customer_subscription_job.rb
@@ -1,0 +1,17 @@
+module Stripe
+  class SyncCustomerSubscriptionJob < ApplicationJob
+    queue_as :default
+    self.queue_adapter = :solid_queue
+
+    def perform(company)
+      subscription_count = company.memberships.active.count
+
+      Stripe::Subscription.update(
+        company.subscription.stripe_id,
+        { items: [
+          {id: company.subscription.item_id,  quantity: subscription_count }
+        ]}
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,6 @@ class User < ApplicationRecord
     membership = memberships.find_by!(company:)
     membership.update!(status: membership.active? ? Membership::INACTIVE : Membership::ACTIVE)
 
-    SyncCustomerSubscriptionJob.perform_async(company.id)
+    Stripe::SyncCustomerSubscriptionJob.perform_later(company)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,8 @@ Rails.application.configure do
     Bullet.add_footer    = true
   end
 
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Settings specified here will take precedence over those in config/application.rb.
   config.view_component.capture_compatibility_patch_enabled = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
     # Bullet.raise         = true # raise an error if n+1 query occurs
   end
 
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # While tests run files are not watched, reloading is not necessary.

--- a/spec/cassettes/Stripe_CreateCustomerJob/perform/creates_a_stripe_customer.yml
+++ b/spec/cassettes/Stripe_CreateCustomerJob/perform/creates_a_stripe_customer.yml
@@ -1,0 +1,476 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: name=Spencer+LLC+28+%7C+Leonel+Adams+IV+28&email=something%40static.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.0.0
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IDNh8s15SDeQKa","request_duration_ms":908}}'
+      Stripe-Version:
+      - '2024-06-20'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.0.0","lang":"ruby","lang_version":"3.2.0 p0 (2022-12-25)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-2.local 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:13:18 PDT
+        2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6030 arm64","hostname":"fwank-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 03 Jul 2024 16:06:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '665'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - f739e8d2-6aec-4f14-8f17-3789b743f35a
+      Original-Request:
+      - req_7HfLjI0dlaIhov
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+      Request-Id:
+      - req_7HfLjI0dlaIhov
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2024-06-20'
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_QPKMlvO3apTjIZ",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1720022805,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "FB0FF49D",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Spencer LLC 28 | Leonel Adams IV 28",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 03 Jul 2024 16:06:45 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/subscriptions
+    body:
+      encoding: UTF-8
+      string: customer=cus_QPKMlvO3apTjIZ&items[0][price]=price_1Oo7tQBLjyMcgacQSNLewS9y&items[0][quantity]=1&trial_period_days=30&trial_settings[end_behavior][missing_payment_method]=cancel&payment_settings[save_default_payment_method]=on_subscription
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.0.0
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7HfLjI0dlaIhov","request_duration_ms":263}}'
+      Stripe-Version:
+      - '2024-06-20'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.0.0","lang":"ruby","lang_version":"3.2.0 p0 (2022-12-25)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-2.local 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:13:18 PDT
+        2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6030 arm64","hostname":"fwank-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 03 Jul 2024 16:06:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4337'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fsubscriptions; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 9a1106d4-3ff5-43df-88c1-2a6f74264a9a
+      Original-Request:
+      - req_zqvU5pzHvjGVEw
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=billing-api-srv"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report?s=billing-api-srv"
+      Request-Id:
+      - req_zqvU5pzHvjGVEw
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2024-06-20'
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "sub_1PYVhhBLjyMcgacQbLF02cP0",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1722614805,
+          "billing_cycle_anchor_config": null,
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1720022805,
+          "currency": "usd",
+          "current_period_end": 1722614805,
+          "current_period_start": 1720022805,
+          "customer": "cus_QPKMlvO3apTjIZ",
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_QPKMtWwDGgqHGw",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1720022806,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 300,
+                  "amount_decimal": "300",
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 300,
+                  "unit_amount_decimal": "300"
+                },
+                "quantity": 1,
+                "subscription": "sub_1PYVhhBLjyMcgacQbLF02cP0",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1PYVhhBLjyMcgacQbLF02cP0"
+          },
+          "latest_invoice": "in_1PYVhhBLjyMcgacQ7kJ4yCs9",
+          "livemode": false,
+          "metadata": {},
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "on_subscription"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": "seti_1PYVhiBLjyMcgacQ9P2Mw5aC",
+          "pending_update": null,
+          "plan": {
+            "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 300,
+            "amount_decimal": "300",
+            "billing_scheme": "per_unit",
+            "created": 1708968188,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_PdOgBPQqj1Ri1R",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1720022805,
+          "status": "trialing",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": 1722614805,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "cancel"
+            }
+          },
+          "trial_start": 1720022805
+        }
+  recorded_at: Wed, 03 Jul 2024 16:06:46 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/customers/cus_QPKMlvO3apTjIZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.0.0
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_zqvU5pzHvjGVEw","request_duration_ms":830}}'
+      Stripe-Version:
+      - '2024-06-20'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.0.0","lang":"ruby","lang_version":"3.2.0 p0 (2022-12-25)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-2.local 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:13:18 PDT
+        2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6030 arm64","hostname":"fwank-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 03 Jul 2024 16:06:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '666'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers%2F%3Acustomer;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+      Request-Id:
+      - req_HBkqidihaLrHYX
+      Stripe-Version:
+      - '2024-06-20'
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_QPKMlvO3apTjIZ",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1720022805,
+          "currency": "usd",
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "FB0FF49D",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Spencer LLC 28 | Leonel Adams IV 28",
+          "next_invoice_sequence": 2,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 03 Jul 2024 16:06:46 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/Stripe_CreateCustomerJob/perform/save_stripe_id_to_company.yml
+++ b/spec/cassettes/Stripe_CreateCustomerJob/perform/save_stripe_id_to_company.yml
@@ -1,0 +1,484 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: name=Nolan%2C+Zemlak+and+Bartoletti+2+%7C+Rev.+Vicenta+Mayert+2&email=something%40static.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_HBkqidihaLrHYX","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 4237a557-f5b5-48fd-a6c7-2356be439f4c
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '684'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 4237a557-f5b5-48fd-a6c7-2356be439f4c
+      Original-Request:
+      - req_XtySh0QQsidBrE
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_XtySh0QQsidBrE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_Rcgx5PCN5fuzU6",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1737404874,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "DB517A48",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Nolan, Zemlak and Bartoletti 2 | Rev. Vicenta Mayert 2",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:54 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/subscriptions
+    body:
+      encoding: UTF-8
+      string: customer=cus_Rcgx5PCN5fuzU6&items[0][price]=price_1Oo7tQBLjyMcgacQSNLewS9y&items[0][quantity]=1&trial_period_days=30&trial_settings[end_behavior][missing_payment_method]=cancel&payment_settings[save_default_payment_method]=on_subscription
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_XtySh0QQsidBrE","request_duration_ms":312}}'
+      Idempotency-Key:
+      - 46bf973c-70de-4071-baca-d46cccbb9207
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4366'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 46bf973c-70de-4071-baca-d46cccbb9207
+      Original-Request:
+      - req_09wvQGn6dgdovD
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_09wvQGn6dgdovD
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "sub_1QjRZeBLjyMcgacQiHSCqEvP",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1739996874,
+          "billing_cycle_anchor_config": null,
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1737404874,
+          "currency": "usd",
+          "current_period_end": 1739996874,
+          "current_period_start": 1737404874,
+          "customer": "cus_Rcgx5PCN5fuzU6",
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_Rcgx2qMh0obRXv",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1737404874,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 300,
+                  "amount_decimal": "300",
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 300,
+                  "unit_amount_decimal": "300"
+                },
+                "quantity": 1,
+                "subscription": "sub_1QjRZeBLjyMcgacQiHSCqEvP",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1QjRZeBLjyMcgacQiHSCqEvP"
+          },
+          "latest_invoice": "in_1QjRZeBLjyMcgacQeLj0IEc2",
+          "livemode": false,
+          "metadata": {},
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "on_subscription"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": "seti_1QjRZeBLjyMcgacQfxa7pGdZ",
+          "pending_update": null,
+          "plan": {
+            "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 300,
+            "amount_decimal": "300",
+            "billing_scheme": "per_unit",
+            "created": 1708968188,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_PdOgBPQqj1Ri1R",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1737404874,
+          "status": "trialing",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": 1739996874,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "cancel"
+            }
+          },
+          "trial_start": 1737404874
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/customers/cus_Rcgx5PCN5fuzU6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_09wvQGn6dgdovD","request_duration_ms":942}}'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '685'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_hAlhmuvPVvvLdo
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_Rcgx5PCN5fuzU6",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1737404874,
+          "currency": "usd",
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "DB517A48",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Nolan, Zemlak and Bartoletti 2 | Rev. Vicenta Mayert 2",
+          "next_invoice_sequence": 2,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:55 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/creates_a_subscription.yml
+++ b/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/creates_a_subscription.yml
@@ -1,0 +1,374 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: name=Funk+Group+4+%7C+Justa+Farrell+4&email=something%40static.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bSlzxL341Fsb8Z","request_duration_ms":923}}'
+      Idempotency-Key:
+      - 29290135-e011-4df5-97fc-26e824daf33a
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '660'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 29290135-e011-4df5-97fc-26e824daf33a
+      Original-Request:
+      - req_dah5t5CWPmupYg
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_dah5t5CWPmupYg
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_RcgxrbJ0oCWlZx",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1737404878,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "0DB33D7B",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Funk Group 4 | Justa Farrell 4",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:58 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/subscriptions
+    body:
+      encoding: UTF-8
+      string: customer=cus_RcgxrbJ0oCWlZx&items[0][price]=price_1Oo7tQBLjyMcgacQSNLewS9y&items[0][quantity]=1&trial_period_days=30&trial_settings[end_behavior][missing_payment_method]=cancel&payment_settings[save_default_payment_method]=on_subscription
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_dah5t5CWPmupYg","request_duration_ms":241}}'
+      Idempotency-Key:
+      - bf56bd15-bb55-47e4-bf08-a062c4de5c18
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4366'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - bf56bd15-bb55-47e4-bf08-a062c4de5c18
+      Original-Request:
+      - req_n0hvNwZAsa5lVH
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_n0hvNwZAsa5lVH
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "sub_1QjRZiBLjyMcgacQbunwB1gz",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1739996878,
+          "billing_cycle_anchor_config": null,
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1737404878,
+          "currency": "usd",
+          "current_period_end": 1739996878,
+          "current_period_start": 1737404878,
+          "customer": "cus_RcgxrbJ0oCWlZx",
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_Rcgxgm10fajcZ7",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1737404879,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 300,
+                  "amount_decimal": "300",
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 300,
+                  "unit_amount_decimal": "300"
+                },
+                "quantity": 1,
+                "subscription": "sub_1QjRZiBLjyMcgacQbunwB1gz",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1QjRZiBLjyMcgacQbunwB1gz"
+          },
+          "latest_invoice": "in_1QjRZiBLjyMcgacQgEXhFVtt",
+          "livemode": false,
+          "metadata": {},
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "on_subscription"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": "seti_1QjRZjBLjyMcgacQCACCEm0x",
+          "pending_update": null,
+          "plan": {
+            "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 300,
+            "amount_decimal": "300",
+            "billing_scheme": "per_unit",
+            "created": 1708968188,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_PdOgBPQqj1Ri1R",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1737404878,
+          "status": "trialing",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": 1739996878,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "cancel"
+            }
+          },
+          "trial_start": 1737404878
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:59 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/saves_without_any_credit_card_information_if_on_a_free_trial_.yml
+++ b/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/saves_without_any_credit_card_information_if_on_a_free_trial_.yml
@@ -1,0 +1,374 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: name=Russel-Mills+3+%7C+Marcelene+Bergstrom+3&email=something%40static.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_T2X307tTStDbpt","request_duration_ms":879}}'
+      Idempotency-Key:
+      - 6cde89e0-f3db-451a-8aea-996371735bf9
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '668'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 6cde89e0-f3db-451a-8aea-996371735bf9
+      Original-Request:
+      - req_yyVnzLPMR1I0td
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_yyVnzLPMR1I0td
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_RcgxKZY6tQWFI3",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1737404876,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "1293A34C",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "Russel-Mills 3 | Marcelene Bergstrom 3",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:57 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/subscriptions
+    body:
+      encoding: UTF-8
+      string: customer=cus_RcgxKZY6tQWFI3&items[0][price]=price_1Oo7tQBLjyMcgacQSNLewS9y&items[0][quantity]=1&trial_period_days=30&trial_settings[end_behavior][missing_payment_method]=cancel&payment_settings[save_default_payment_method]=on_subscription
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yyVnzLPMR1I0td","request_duration_ms":260}}'
+      Idempotency-Key:
+      - afa9918d-5925-4c94-9507-3e364de9a08d
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4366'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - afa9918d-5925-4c94-9507-3e364de9a08d
+      Original-Request:
+      - req_bSlzxL341Fsb8Z
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_bSlzxL341Fsb8Z
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "sub_1QjRZhBLjyMcgacQDv4ne0rp",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1739996877,
+          "billing_cycle_anchor_config": null,
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1737404877,
+          "currency": "usd",
+          "current_period_end": 1739996877,
+          "current_period_start": 1737404877,
+          "customer": "cus_RcgxKZY6tQWFI3",
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_RcgxTrCYSilQq2",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1737404877,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 300,
+                  "amount_decimal": "300",
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 300,
+                  "unit_amount_decimal": "300"
+                },
+                "quantity": 1,
+                "subscription": "sub_1QjRZhBLjyMcgacQDv4ne0rp",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1QjRZhBLjyMcgacQDv4ne0rp"
+          },
+          "latest_invoice": "in_1QjRZhBLjyMcgacQVKLCpXfd",
+          "livemode": false,
+          "metadata": {},
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "on_subscription"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": "seti_1QjRZhBLjyMcgacQlpAbg89j",
+          "pending_update": null,
+          "plan": {
+            "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 300,
+            "amount_decimal": "300",
+            "billing_scheme": "per_unit",
+            "created": 1708968188,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_PdOgBPQqj1Ri1R",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1737404877,
+          "status": "trialing",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": 1739996877,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "cancel"
+            }
+          },
+          "trial_start": 1737404877
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:57 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/stores_stripe_price_id_the_rest_comes_in_via_webhooks.yml
+++ b/spec/cassettes/Stripe_CreateCustomerJob/perform/stripe_subscription/stores_stripe_price_id_the_rest_comes_in_via_webhooks.yml
@@ -1,0 +1,374 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: name=static+company+name+%7C+static+name&email=something%40static.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_hAlhmuvPVvvLdo","request_duration_ms":156}}'
+      Idempotency-Key:
+      - 6fd19b96-459d-4f7f-a023-ae4a26ca41b8
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '663'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 6fd19b96-459d-4f7f-a023-ae4a26ca41b8
+      Original-Request:
+      - req_re2pOavkoRBSwz
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_re2pOavkoRBSwz
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_Rcgxf9NpA8S0VU",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1737404875,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "something@static.com",
+          "invoice_prefix": "5F41434D",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "static company name | static name",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:55 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/subscriptions
+    body:
+      encoding: UTF-8
+      string: customer=cus_Rcgxf9NpA8S0VU&items[0][price]=price_1Oo7tQBLjyMcgacQSNLewS9y&items[0][quantity]=1&trial_period_days=30&trial_settings[end_behavior][missing_payment_method]=cancel&payment_settings[save_default_payment_method]=on_subscription
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.3.1
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_re2pOavkoRBSwz","request_duration_ms":243}}'
+      Idempotency-Key:
+      - 36e63f2e-5eb5-46c3-81e3-03c247af33b9
+      Stripe-Version:
+      - 2024-12-18.acacia
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"13.3.1","lang":"ruby","lang_version":"3.4.1 p0 (2024-12-25)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        fwank-4.local 24.2.0 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:41 PST
+        2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6030 arm64","hostname":"fwank-4.local"}'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 20 Jan 2025 20:27:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4366'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri https://q.stripe.com/csp-violation?q=wRZzT4ZhadxvMXAFfxU-evsfbT9QlZCoTUa56sM9XXkP27LtDHYSHWZQyAwQ5i8vs66dz7PU985xsSGM
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 36e63f2e-5eb5-46c3-81e3-03c247af33b9
+      Original-Request:
+      - req_T2X307tTStDbpt
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_T2X307tTStDbpt
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2024-12-18.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABC
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "sub_1QjRZfBLjyMcgacQtvA6nguq",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1739996875,
+          "billing_cycle_anchor_config": null,
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1737404875,
+          "currency": "usd",
+          "current_period_end": 1739996875,
+          "current_period_start": 1737404875,
+          "customer": "cus_Rcgxf9NpA8S0VU",
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_RcgxHQmoCAWDBP",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1737404876,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 300,
+                  "amount_decimal": "300",
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1708968188,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_PdOgBPQqj1Ri1R",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 300,
+                  "unit_amount_decimal": "300"
+                },
+                "quantity": 1,
+                "subscription": "sub_1QjRZfBLjyMcgacQtvA6nguq",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1QjRZfBLjyMcgacQtvA6nguq"
+          },
+          "latest_invoice": "in_1QjRZfBLjyMcgacQa0w78okT",
+          "livemode": false,
+          "metadata": {},
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "on_subscription"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": "seti_1QjRZgBLjyMcgacQECZjhQEu",
+          "pending_update": null,
+          "plan": {
+            "id": "price_1Oo7tQBLjyMcgacQSNLewS9y",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 300,
+            "amount_decimal": "300",
+            "billing_scheme": "per_unit",
+            "created": 1708968188,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_PdOgBPQqj1Ri1R",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1737404875,
+          "status": "trialing",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": 1739996875,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "cancel"
+            }
+          },
+          "trial_start": 1737404875
+        }
+  recorded_at: Mon, 20 Jan 2025 20:27:56 GMT
+recorded_with: VCR 6.3.1

--- a/spec/commands/add_user_to_company_spec.rb
+++ b/spec/commands/add_user_to_company_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "AddUserToCompany" do
   context "for all users" do
     it "sends a welcome email from the new company" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       AddUserToCompany.new(
         email: user_email = Faker::Internet.email,
@@ -80,7 +80,7 @@ RSpec.describe "AddUserToCompany" do
 
     it "updates the company's Stripe subscription count" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       AddUserToCompany.new(
         email: Faker::Internet.email,
@@ -93,7 +93,7 @@ RSpec.describe "AddUserToCompany" do
   context "when given an existing user's email address" do
     it "adds the user to the company" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       user = create(:user)
 
@@ -110,7 +110,7 @@ RSpec.describe "AddUserToCompany" do
 
     it "does not create a new user" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
       user = create(:user)
 
       expect do
@@ -126,7 +126,7 @@ RSpec.describe "AddUserToCompany" do
   context "when given an new user email address" do
     it "creates a new user" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       email = Faker::Internet.email
 
@@ -145,7 +145,7 @@ RSpec.describe "AddUserToCompany" do
 
     it "adds the user to the company" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       user = AddUserToCompany.new(
         email: Faker::Internet.email,
@@ -158,7 +158,7 @@ RSpec.describe "AddUserToCompany" do
 
     it "does not set the current_company for existing users" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       user = create(:user)
       current_company = user.current_company
@@ -176,7 +176,7 @@ RSpec.describe "AddUserToCompany" do
 
     it "sets the company as the user's current company for new users" do
       company = create(:membership).company
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
 
       email = Faker::Internet.email
 

--- a/spec/commands/create_new_company_spec.rb
+++ b/spec/commands/create_new_company_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CreateNewCompany do
   describe "#call" do
     it "creates a company" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       expect {
         CreateNewCompany.new(
           company_name: registration.company_name,
@@ -17,7 +17,7 @@ RSpec.describe CreateNewCompany do
 
     it "creates a user" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       expect {
         CreateNewCompany.new(
           company_name: registration.company_name,
@@ -30,7 +30,7 @@ RSpec.describe CreateNewCompany do
 
     it "associates the user with the company" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -44,7 +44,7 @@ RSpec.describe CreateNewCompany do
 
     it "sets the user's name and email from the registration" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -57,7 +57,7 @@ RSpec.describe CreateNewCompany do
 
     it "sets the user's role to owner" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -69,7 +69,7 @@ RSpec.describe CreateNewCompany do
 
     it "sets the user's status to active" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -81,7 +81,7 @@ RSpec.describe CreateNewCompany do
 
     it "sets the registration's registered_at timestamp" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -93,7 +93,7 @@ RSpec.describe CreateNewCompany do
 
     it "creates a subscription" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
       CreateNewCompany.new(
         company_name: registration.company_name,
         email: registration.email,
@@ -106,7 +106,7 @@ RSpec.describe CreateNewCompany do
 
     it "enqueues a job to create a stripe customer" do
       registration = create(:registration)
-      expect(CreateStripeCustomerJob).to receive(:perform_async)
+      expect(Stripe::CreateCustomerJob).to receive(:perform_later)
 
       command = CreateNewCompany.new(
         company_name: registration.company_name,

--- a/spec/jobs/stripe/create_customer_job_spec.rb
+++ b/spec/jobs/stripe/create_customer_job_spec.rb
@@ -1,20 +1,20 @@
 require "rails_helper"
 
-RSpec.describe CreateStripeCustomerJob, type: :job, vcr: true do
+RSpec.describe Stripe::CreateCustomerJob, type: :job, vcr: true do
   describe "perform" do
     before do
       expect(Company.count).to eq(0)
     end
 
     it "fails if it cannot find the company" do
-      expect { CreateStripeCustomerJob.perform_inline(1) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { Stripe::CreateCustomerJob.perform_now(Company.new) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "creates a stripe customer" do
       registration = create(:registration, email: "something@static.com")
       registration.register!
 
-      CreateStripeCustomerJob.perform_inline(Company.first.id)
+      Stripe::CreateCustomerJob.perform_now(Company.first)
 
       user = registration.reload.user
       expect(Company.count).to eq(1)
@@ -28,7 +28,7 @@ RSpec.describe CreateStripeCustomerJob, type: :job, vcr: true do
       registration = create(:registration, email: "something@static.com")
       registration.register!
 
-      CreateStripeCustomerJob.perform_inline(Company.first.id)
+      Stripe::CreateCustomerJob.perform_now(Company.first)
 
       expect(Company.count).to eq(1)
       company = Company.first
@@ -43,7 +43,7 @@ RSpec.describe CreateStripeCustomerJob, type: :job, vcr: true do
         registration = create(:registration, email: "something@static.com")
         registration.register!
 
-        CreateStripeCustomerJob.perform_inline(Company.first.id)
+        Stripe::CreateCustomerJob.perform_now(Company.first)
 
         expect(Company.count).to eq(1)
         company = Company.first
@@ -55,7 +55,7 @@ RSpec.describe CreateStripeCustomerJob, type: :job, vcr: true do
         registration = create(:registration, email: "something@static.com")
         registration.register!
 
-        CreateStripeCustomerJob.perform_inline(Company.first.id)
+        Stripe::CreateCustomerJob.perform_now(Company.first)
 
         company = Company.first
         subscription = company.subscription
@@ -74,7 +74,7 @@ RSpec.describe CreateStripeCustomerJob, type: :job, vcr: true do
         )
         registration.register!
 
-        CreateStripeCustomerJob.perform_inline(Company.first.id)
+        Stripe::CreateCustomerJob.perform_now(Company.first)
 
         company = Company.first
         subscription = company.subscription

--- a/spec/jobs/stripe/sync_customer_subscription_job_spec.rb
+++ b/spec/jobs/stripe/sync_customer_subscription_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Stripe::SyncCustomerSubscriptionJob, type: :job, vcr: true do
+
+  context "perform" do
+    it "fails if it cannot find the company" do
+      expect { Stripe::SyncCustomerSubscriptionJob.perform_now(Company.new) }.to raise_error { ActiveRecord::RecordNotFound }
+    end
+
+    it "informs Stripe of the new quantity" do
+      registration = create(:registration, email: "something@static.com")
+      registration.register!
+      expect(Company.count).to eq(1)
+
+      company = Company.first
+
+      expect(company.memberships.active.count).to eq(1)
+      create(:membership, company: company)
+      expect(company.memberships.active.count).to eq(2)
+
+      expect(Stripe::Subscription).to receive(:update).with(
+        company.subscription.stripe_id,
+        { items: [
+          {id: company.subscription.item_id,  quantity: 2 }
+        ]}
+      )
+
+      Stripe::SyncCustomerSubscriptionJob.perform_now(company)
+    end
+  end
+end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Registration, type: :model do
     describe "register!" do
       it "raises RegistrationNotAvailableError if claimed?" do
         registration = create(:registration)
-        expect(CreateStripeCustomerJob).to receive(:perform_async)
+        expect(Stripe::CreateCustomerJob).to receive(:perform_later)
 
         registration.register!
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe User, type: :model do
       company = membership.company
       user = membership.user
 
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
       user.toggle_status!(company:)
       expect(user.inactive?(company:)).to be_truthy
     end
@@ -84,7 +84,7 @@ RSpec.describe User, type: :model do
       company = membership.company
       user = membership.user
 
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
       user.toggle_status!(company:)
       expect(user.inactive?(company:)).to be_falsey
     end
@@ -95,7 +95,7 @@ RSpec.describe User, type: :model do
       second_membership = create(:membership, status: Membership::INACTIVE, user:)
       expect(user.current_company).to eq(second_membership.company)
 
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(first_membership.company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(first_membership.company)
       user.toggle_status!(company: first_membership.company)
     end
 
@@ -104,7 +104,7 @@ RSpec.describe User, type: :model do
       company = membership.company
       user = membership.user
 
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async).with(company.id)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later).with(company)
       user.toggle_status!(company:)
     end
   end

--- a/spec/system/user_management_spec.rb
+++ b/spec/system/user_management_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "User Management", type: :system do
       fill_in "Full name", with: Faker::Name.name
       fill_in "Email", with: Faker::Internet.email
 
-      expect(SyncCustomerSubscriptionJob).to receive(:perform_async)
+      expect(Stripe::SyncCustomerSubscriptionJob).to receive(:perform_later)
 
       expect do
         click_button "Create"


### PR DESCRIPTION
Closes https://github.com/goinvo/staffplan_redux/issues/416

tl;dr: migrates the two background jobs for StaffPlan to utilize [SolidQueue](https://github.com/rails/solid_queue), the new default worker queue for Rails apps. It eliminates the need for `redis` to support the application's use of a background worker queue, simplifying the dependencies and points of failure 🎉 