### PR TITLE
feat: implement assignment focused update if a future work week is modified

### DIFF
--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -13,6 +13,8 @@ class WorkWeek < ApplicationRecord
   validates :actual_hours, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 168 }
   validate :no_future_actual_hours
 
+  before_commit :update_assignment_focused_if_future_work_week
+
   def is_future_work_week?(relative_to_date: Date.today)
     relative_to_date.cwyear < year || (
       year == relative_to_date.cwyear && cweek > relative_to_date.cweek
@@ -20,6 +22,12 @@ class WorkWeek < ApplicationRecord
   end
 
   private
+
+  def update_assignment_focused_if_future_work_week
+    return unless is_future_work_week?
+
+    assignment.update(focused: true)
+  end
 
   def no_future_actual_hours
     return if actual_hours_allowed?

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -40,4 +40,24 @@ RSpec.describe WorkWeek, type: :model do
       expect(work_week.is_future_work_week?).to be_falsey
     end
   end
+
+  context "callbacks" do
+    it "updates the assignment focused attribute if the work week is in the future" do
+      work_week = create(:work_week, year: 1.year.from_now.to_date.cwyear, cweek: 4.weeks.from_now.to_date.cweek)
+      work_week.assignment.update(focused: false)
+
+      work_week.update(estimated_hours: 1)
+
+      expect(work_week.assignment.focused).to be_truthy
+    end
+
+    it "does not update the assignment focused attribute if the work week is in the past" do
+      work_week = create(:work_week, year: 1.year.ago.to_date.cwyear, cweek: 4.weeks.ago.to_date.cweek)
+      work_week.assignment.update(focused: false)
+
+      work_week.update(estimated_hours: 1)
+
+      expect(work_week.assignment.focused).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Implements behavior that if an un-focused assignment has its future estimated hours updated (since you can't update actual hours for a future work week) the assignment is focused.