### PR TITLE
bug fix: consider the correct company when querying for a user's role, active status, projects, and assignments

### DIFF
--- a/app/graphql/types/staff_plan/user_type.rb
+++ b/app/graphql/types/staff_plan/user_type.rb
@@ -22,23 +22,23 @@ module Types
       field :assignments, [Types::StaffPlan::AssignmentType], null: false, description: "Fetches all of the user's assignments for the current company."
 
       def assignments
-        object.assignments.includes(:work_weeks, project: :client).where(project_id: object.current_company.projects.map(&:id))
+        object.assignments.includes(:work_weeks, project: :client).where(project_id: context[:current_company].projects.map(&:id))
       end
 
       field :projects, [Types::StaffPlan::ProjectType], null: false, description: "Fetches all projects for the current user for the current company."
 
       def projects
-        object.projects.includes(assignments: [:work_weeks, project: :client]).where(client_id: object.current_company.clients.map(&:id))
+        object.projects.includes(assignments: [:work_weeks, project: :client]).where(client_id: context[:current_company].clients.map(&:id))
       end
 
       field :role, String, null: false, description: "The role of the user in the current_company"
       def role
-        object.role(company: object.current_company)
+        object.role(company: context[:current_company])
       end
 
       field :is_active, Boolean, null: false, description: "Whether the user is an active member of the current company."
       def is_active
-        object.status(company: object.current_company) == Membership::ACTIVE
+        object.status(company: context[:current_company]) == Membership::ACTIVE
       end
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/spec/graphql/query_type_spec.rb
+++ b/spec/graphql/query_type_spec.rb
@@ -114,5 +114,90 @@ RSpec.describe "QueryType" do
       expect(result["errors"]).to be_nil
       expect(user["isActive"]).to eq(false)
     end
+
+    it "considers membership status for the request's current company" do
+      query_string = <<-GRAPHQL
+        query {
+          viewer {
+            isActive
+          }
+        }
+      GRAPHQL
+
+      inactive_membership = create(:membership, status: Membership::INACTIVE)
+      user = inactive_membership.user
+      active_membership = create(:membership, status: Membership::ACTIVE, user:)
+
+      # users.current_company is set to the active membership
+      assert_equal active_membership.company, user.current_company
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: inactive_membership.company
+        }
+      )
+
+      user = result["data"]["viewer"]
+      expect(result["errors"]).to be_nil
+      expect(user["isActive"]).to eq(false)
+    end
+  end
+
+  context "user#role" do
+    it "it returns the role of the owner in the request's company" do
+      query_string = <<-GRAPHQL
+        query {
+          viewer {
+            role
+          }
+        }
+      GRAPHQL
+
+      user = create(:membership).user
+      company = user.current_company
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: company
+        }
+      )
+
+      user = result["data"]["viewer"]
+      expect(result["errors"]).to be_nil
+      expect(user["role"]).to eq(Membership::OWNER)
+    end
+
+    it "it considers the request's company only" do
+      query_string = <<-GRAPHQL
+        query {
+          viewer {
+            role
+          }
+        }
+      GRAPHQL
+
+      active_membership = create(:membership, role: Membership::MEMBER, status: Membership::ACTIVE)
+      user = active_membership.user
+      inactive_membership = create(:membership, status: Membership::INACTIVE, user:)
+
+      # users.current_company is set to the active membership
+      assert_equal inactive_membership.company, user.current_company
+
+      result = StaffplanReduxSchema.execute(
+        query_string,
+        context: {
+          current_user: user,
+          current_company: active_membership.company
+        }
+      )
+
+      user = result["data"]["viewer"]
+      expect(result["errors"]).to be_nil
+      expect(user["role"]).to eq(Membership::MEMBER)
+    end
   end
 end


### PR DESCRIPTION
This should fix the issue of @HankC138 still showing up GoInvo's list of active users despite being deactivated in their account.